### PR TITLE
Add lower pairs support for Forall Op

### DIFF
--- a/tests/filecheck/lower-pairs/forall_args.mlir
+++ b/tests/filecheck/lower-pairs/forall_args.mlir
@@ -1,0 +1,27 @@
+// RUN: xdsl-smt "%s" -p=lower-pairs | filecheck "%s"
+
+// Check that pair function arguments are split into multiple arguments in a forall loop
+
+"builtin.module"() ({
+  %0 = "smt.forall"() ({
+^0(%1 : !smt.utils.pair<!smt.bv.bv<4>, !smt.bool>, %2 : !smt.utils.pair<!smt.bv.bv<4>, !smt.bool>):
+  %3 = "smt.utils.first"(%1) : (!smt.utils.pair<!smt.bv.bv<4>, !smt.bool>) -> !smt.bv.bv<4>
+  %4 = "smt.utils.first"(%2) : (!smt.utils.pair<!smt.bv.bv<4>, !smt.bool>) -> !smt.bv.bv<4>
+  %5 = "smt.utils.second"(%1) : (!smt.utils.pair<!smt.bv.bv<4>, !smt.bool>) -> !smt.bool
+  %6 = "smt.utils.second"(%2) : (!smt.utils.pair<!smt.bv.bv<4>, !smt.bool>) -> !smt.bool
+  %7 = "smt.eq"(%3, %4) : (!smt.bv.bv<4>, !smt.bv.bv<4>) -> !smt.bool
+  %8 = "smt.and"(%5, %6) : (!smt.bool, !smt.bool) -> !smt.bool
+  %9 = "smt.implies"(%7, %8) : (!smt.bool, !smt.bool) -> !smt.bool
+  "smt.yield"(%9) : (!smt.bool) -> ()
+}) : () -> !smt.bool
+  "smt.assert"(%0) : (!smt.bool) -> ()
+}) : () -> ()
+
+// CHECK:      %0 = "smt.forall"() ({
+// CHECK-NEXT: ^0(%1 : !smt.bv.bv<4>, %2 : !smt.bool, %3 : !smt.bv.bv<4>, %4 : !smt.bool):
+// CHECK-NEXT:   %5 = "smt.eq"(%1, %3) : (!smt.bv.bv<4>, !smt.bv.bv<4>) -> !smt.bool
+// CHECK-NEXT:   %6 = "smt.and"(%2, %4) : (!smt.bool, !smt.bool) -> !smt.bool
+// CHECK-NEXT:   %7 = "smt.implies"(%5, %6) : (!smt.bool, !smt.bool) -> !smt.bool
+// CHECK-NEXT:   "smt.yield"(%7) : (!smt.bool) -> ()
+// CHECK-NEXT: }) : () -> !smt.bool
+// CHECK-NEXT: "smt.assert"(%0) : (!smt.bool) -> ()

--- a/tests/filecheck/verify-pdl/extract_to_select.mlir
+++ b/tests/filecheck/verify-pdl/extract_to_select.mlir
@@ -8,7 +8,7 @@ builtin.module {
     %operand = pdl.operand : %type
     %low_bit_attr = pdl.attribute = 2 : i32
 
-    %extract = pdl.operation "comb.extract"(%operand : !pdl.value) { "low_bit" = %low_bit_attr} -> (%extract_type : !pdl.type)
+    %extract = pdl.operation "comb.extract"(%operand : !pdl.value) { "lowBit" = %low_bit_attr} -> (%extract_type : !pdl.type)
 
     pdl.rewrite %extract {
       %shift_cst_attr = pdl.attribute = 2 : i8
@@ -18,7 +18,7 @@ builtin.module {
       %shift_res = pdl.result 0 of %shift_op
 
       %new_extract_cst = pdl.attribute = 0 : i32
-      %new_extract_op = pdl.operation "comb.extract"(%shift_res : !pdl.value) { "low_bit" = %new_extract_cst } -> (%extract_type : !pdl.type)
+      %new_extract_op = pdl.operation "comb.extract"(%shift_res : !pdl.value) { "lowBit" = %new_extract_cst } -> (%extract_type : !pdl.type)
 
       pdl.replace %extract with %new_extract_op
     }

--- a/xdsl_smt/passes/lower_pairs.py
+++ b/xdsl_smt/passes/lower_pairs.py
@@ -19,7 +19,7 @@ from xdsl.rewriter import Rewriter, InsertPoint
 from xdsl.passes import ModulePass
 from xdsl.utils.hints import isa
 
-from ..dialects.smt_dialect import CallOp, DeclareConstOp, DefineFunOp, ReturnOp
+from ..dialects.smt_dialect import CallOp, DeclareConstOp, DefineFunOp, ReturnOp, ForallOp
 from ..dialects.smt_utils_dialect import (
     AnyPairType,
     FirstOp,
@@ -160,6 +160,23 @@ def remove_pairs_from_function_return(module: ModuleOp):
                 Rewriter.replace_op(call, [callFirst, callSecond, mergeCalls])
 
 
+class LowerForallArgsPattern(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, forall: ForallOp, rewriter: PatternRewriter):
+        forall_block = forall.body.block
+
+        for i, arg in enumerate(forall_block.args):
+            if isa(arg.type, AnyPairType):
+                second_arg = forall_block.insert_arg(arg.type.second, i)
+                first_arg = forall_block.insert_arg(arg.type.first, i)
+                pair_op = PairOp(first_arg, second_arg)
+                forall_block.insert_op_before(pair_op, forall_block.ops.first)
+                arg.replace_by(pair_op.res)
+                forall_block.erase_arg(arg)
+                rewriter.has_done_action = True
+                break
+
+
 class LowerDeclareConstPattern(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: DeclareConstOp, rewriter: PatternRewriter):
@@ -183,6 +200,7 @@ class LowerPairs(ModulePass):
         walker = PatternRewriteWalker(
             GreedyRewritePatternApplier(
                 [
+                    LowerForallArgsPattern(),
                     RemovePairArgsFunction(),
                     RemovePairArgsCall(),
                     LowerDeclareConstPattern(),
@@ -201,6 +219,5 @@ class LowerPairs(ModulePass):
             )
         )
         walker.rewrite_module(op)
-
         # Apply DCE pass
         DeadCodeElimination().apply(ctx, op)

--- a/xdsl_smt/passes/lower_pairs.py
+++ b/xdsl_smt/passes/lower_pairs.py
@@ -19,7 +19,13 @@ from xdsl.rewriter import Rewriter, InsertPoint
 from xdsl.passes import ModulePass
 from xdsl.utils.hints import isa
 
-from ..dialects.smt_dialect import CallOp, DeclareConstOp, DefineFunOp, ReturnOp, ForallOp
+from ..dialects.smt_dialect import (
+    CallOp,
+    DeclareConstOp,
+    DefineFunOp,
+    ReturnOp,
+    ForallOp,
+)
 from ..dialects.smt_utils_dialect import (
     AnyPairType,
     FirstOp,
@@ -170,6 +176,7 @@ class LowerForallArgsPattern(RewritePattern):
                 second_arg = forall_block.insert_arg(arg.type.second, i)
                 first_arg = forall_block.insert_arg(arg.type.first, i)
                 pair_op = PairOp(first_arg, second_arg)
+                assert forall_block.ops.first is not None
                 forall_block.insert_op_before(pair_op, forall_block.ops.first)
                 arg.replace_by(pair_op.res)
                 forall_block.erase_arg(arg)


### PR DESCRIPTION
This PR adds lower-pairs support for Forall Op by keeping checking its arguments until there is no more pair args 