### PR TITLE
Add LowerEqPattern and LowerDistinctPattern for pair types

### DIFF
--- a/tests/filecheck/lower-pairs/distinct_pairs.mlir
+++ b/tests/filecheck/lower-pairs/distinct_pairs.mlir
@@ -1,0 +1,23 @@
+// RUN: xdsl-smt "%s" -p=lower-pairs | filecheck "%s"
+
+// Lower pairs from a "smt.distinct" operation.
+
+builtin.module {
+  %0 = "smt.declare_const"() : () -> !smt.utils.pair<!smt.bool, !smt.utils.pair<!smt.bv.bv<32>, !smt.bool>>
+  %1 = "smt.declare_const"() : () -> !smt.utils.pair<!smt.bool, !smt.utils.pair<!smt.bv.bv<32>, !smt.bool>>
+  %distinct = "smt.distinct"(%0, %1) : (!smt.utils.pair<!smt.bool, !smt.utils.pair<!smt.bv.bv<32>, !smt.bool>>, !smt.utils.pair<!smt.bool, !smt.utils.pair<!smt.bv.bv<32>, !smt.bool>>) -> !smt.bool
+  "smt.assert"(%distinct) : (!smt.bool) -> ()
+}
+
+// CHECK:       %const_first = "smt.declare_const"() : () -> !smt.bool
+// CHECK-NEXT:  %const_second_first = "smt.declare_const"() : () -> !smt.bv.bv<32>
+// CHECK-NEXT:  %const_second_second = "smt.declare_const"() : () -> !smt.bool
+// CHECK:       %const_first_1 = "smt.declare_const"() : () -> !smt.bool
+// CHECK-NEXT:  %const_second_first_1 = "smt.declare_const"() : () -> !smt.bv.bv<32>
+// CHECK-NEXT:  %const_second_second_1 = "smt.declare_const"() : () -> !smt.bool
+// CHECK-NEXT:  %distinct = "smt.distinct"(%const_first, %const_first_1) : (!smt.bool, !smt.bool) -> !smt.bool
+// CHECK-NEXT:  %distinct_1 = "smt.distinct"(%const_second_first, %const_second_first_1) : (!smt.bv.bv<32>, !smt.bv.bv<32>) -> !smt.bool
+// CHECK-NEXT:  %distinct_2 = "smt.distinct"(%const_second_second, %const_second_second_1) : (!smt.bool, !smt.bool) -> !smt.bool
+// CHECK-NEXT:  %distinct_3 = "smt.or"(%distinct_1, %distinct_2) : (!smt.bool, !smt.bool) -> !smt.bool
+// CHECK-NEXT:  %distinct_4 = "smt.or"(%distinct, %distinct_3) : (!smt.bool, !smt.bool) -> !smt.bool
+// CHECK-NEXT:  "smt.assert"(%distinct_4) : (!smt.bool) -> ()

--- a/tests/filecheck/lower-pairs/eq_pairs.mlir
+++ b/tests/filecheck/lower-pairs/eq_pairs.mlir
@@ -1,0 +1,23 @@
+// RUN: xdsl-smt "%s" -p=lower-pairs | filecheck "%s"
+
+// Lower pairs from a "smt.eq" operation.
+
+builtin.module {
+  %0 = "smt.declare_const"() : () -> !smt.utils.pair<!smt.bool, !smt.utils.pair<!smt.bv.bv<32>, !smt.bool>>
+  %1 = "smt.declare_const"() : () -> !smt.utils.pair<!smt.bool, !smt.utils.pair<!smt.bv.bv<32>, !smt.bool>>
+  %eq = "smt.eq"(%0, %1) : (!smt.utils.pair<!smt.bool, !smt.utils.pair<!smt.bv.bv<32>, !smt.bool>>, !smt.utils.pair<!smt.bool, !smt.utils.pair<!smt.bv.bv<32>, !smt.bool>>) -> !smt.bool
+  "smt.assert"(%eq) : (!smt.bool) -> ()
+}
+
+// CHECK:       %const_first = "smt.declare_const"() : () -> !smt.bool
+// CHECK-NEXT:  %const_second_first = "smt.declare_const"() : () -> !smt.bv.bv<32>
+// CHECK-NEXT:  %const_second_second = "smt.declare_const"() : () -> !smt.bool
+// CHECK:       %const_first_1 = "smt.declare_const"() : () -> !smt.bool
+// CHECK-NEXT:  %const_second_first_1 = "smt.declare_const"() : () -> !smt.bv.bv<32>
+// CHECK-NEXT:  %const_second_second_1 = "smt.declare_const"() : () -> !smt.bool
+// CHECK-NEXT:  %eq = "smt.eq"(%const_first, %const_first_1) : (!smt.bool, !smt.bool) -> !smt.bool
+// CHECK-NEXT:  %eq_1 = "smt.eq"(%const_second_first, %const_second_first_1) : (!smt.bv.bv<32>, !smt.bv.bv<32>) -> !smt.bool
+// CHECK-NEXT:  %eq_2 = "smt.eq"(%const_second_second, %const_second_second_1) : (!smt.bool, !smt.bool) -> !smt.bool
+// CHECK-NEXT:  %eq_3 = "smt.and"(%eq_1, %eq_2) : (!smt.bool, !smt.bool) -> !smt.bool
+// CHECK-NEXT:  %eq_4 = "smt.and"(%eq, %eq_3) : (!smt.bool, !smt.bool) -> !smt.bool
+// CHECK-NEXT:  "smt.assert"(%eq_4) : (!smt.bool) -> ()


### PR DESCRIPTION
This PR includes 4 changes:
1. LowerEqPattern
For a pair eq  comparison, we have
```
(= (pair lhsFirst lhsSecond) (pair rhsFirst rhsSecond))
->
(and (= lhsFirst rhsFirst) (= lhsSecond rhsSecond))
```

2. LowerDistinctPattern
For a pair distinct comparison, we have
```
(distinct (pair lhsFirst lhsSecond) (pair rhsFirst rhsSecond))
->
(or (distinct lhsFirst rhsFirst) (distinct lhsSecond rhsSecond))
```
3. A test case for LowerEqPattern
4. A test case for LowerDistinctPattern