### PR TITLE
Remove operands because of binOp

### DIFF
--- a/xdsl_smt/dialects/transfer.py
+++ b/xdsl_smt/dialects/transfer.py
@@ -356,52 +356,20 @@ class ExtractOp(IRDLOperation):
 class GetLowBitsOp(BinOp):
     name = "transfer.get_low_bits"
 
-    T: ClassVar = VarConstraint(
-        "T", irdl_to_attr_constraint(TransIntegerType | IntegerType)
-    )
-
-    val: Operand = operand_def(T)
-    low_bits: Operand = operand_def(T)
-    result: OpResult = result_def(T)
-
 
 @irdl_op_definition
 class SetHighBitsOp(BinOp):
     name = "transfer.set_high_bits"
-
-    T: ClassVar = VarConstraint(
-        "T", irdl_to_attr_constraint(TransIntegerType | IntegerType)
-    )
-
-    val: Operand = operand_def(T)
-    high_bits: Operand = operand_def(T)
-    result: OpResult = result_def(T)
 
 
 @irdl_op_definition
 class SetLowBitsOp(BinOp):
     name = "transfer.set_low_bits"
 
-    T: ClassVar = VarConstraint(
-        "T", irdl_to_attr_constraint(TransIntegerType | IntegerType)
-    )
-
-    val: Operand = operand_def(T)
-    low_bits: Operand = operand_def(T)
-    result: OpResult = result_def(T)
-
 
 @irdl_op_definition
 class SetSignBitOp(BinOp):
     name = "transfer.set_sign_bit"
-
-    T: ClassVar = VarConstraint(
-        "T", irdl_to_attr_constraint(TransIntegerType | IntegerType)
-    )
-
-    val: Operand = operand_def(T)
-    sign_bit: Operand = operand_def(T)
-    result: OpResult = result_def(T)
 
 
 @irdl_op_definition


### PR DESCRIPTION
This PR removes extra operand definitions because of extension from BinOp.