### PR TITLE
Add implementations for more SMT operations

### DIFF
--- a/tests/filecheck/xdsl-smt-run/ite.mlir
+++ b/tests/filecheck/xdsl-smt-run/ite.mlir
@@ -1,0 +1,9 @@
+// RUN: xdsl-smt-run %s --args="#smt.bool_attr<false>,#smt.bool_attr<false>,#smt.bool_attr<true>" | FileCheck %s
+
+%fun = "smt.define_fun"() ({
+^0(%cond : !smt.bool, %then : !smt.bool, %else : !smt.bool):
+  %r = "smt.ite"(%cond, %then, %else) : (!smt.bool, !smt.bool, !smt.bool) -> !smt.bool
+  "smt.return"(%r) : (!smt.bool) -> ()
+}) : () -> ((!smt.bool, !smt.bool, !smt.bool) -> !smt.bool)
+
+// CHECK: True

--- a/xdsl_smt/interpreters/smt.py
+++ b/xdsl_smt/interpreters/smt.py
@@ -38,3 +38,46 @@ class SMTFunctions(InterpreterFunctions):
     ) -> tuple[Any, ...]:
         assert isinstance(args[0], bool)
         return (not args[0],)
+
+    @impl(smt.AndOp)
+    def run_and(
+        self, interpreter: Interpreter, op: smt.AndOp, args: tuple[Any, ...]
+    ) -> tuple[Any, ...]:
+        assert isinstance(args[0], bool)
+        assert isinstance(args[1], bool)
+        return (args[0] and args[1],)
+
+    @impl(smt.ImpliesOp)
+    def run_implies(
+        self, interpreter: Interpreter, op: smt.ImpliesOp, args: tuple[Any, ...]
+    ) -> tuple[Any, ...]:
+        assert isinstance(args[0], bool)
+        assert isinstance(args[1], bool)
+        return (not args[0] or args[1],)
+
+    @impl(smt.XorOp)
+    def run_xor(
+        self, interpreter: Interpreter, op: smt.XorOp, args: tuple[Any, ...]
+    ) -> tuple[Any, ...]:
+        assert isinstance(args[0], bool)
+        assert isinstance(args[1], bool)
+        return (args[0] != args[1],)
+
+    @impl(smt.DistinctOp)
+    def run_distinct(
+        self, interpreter: Interpreter, op: smt.DistinctOp, args: tuple[Any, ...]
+    ) -> tuple[Any, ...]:
+        return (args[0] != args[1],)
+
+    @impl(smt.EqOp)
+    def run_eq(
+        self, interpreter: Interpreter, op: smt.EqOp, args: tuple[Any, ...]
+    ) -> tuple[Any, ...]:
+        return (args[0] == args[1],)
+
+    @impl(smt.IteOp)
+    def run_ite(
+        self, interpreter: Interpreter, op: smt.IteOp, args: tuple[Any, ...]
+    ) -> tuple[Any, ...]:
+        assert isinstance(args[0], bool)
+        return (args[1] if args[0] else args[2],)


### PR DESCRIPTION
This implements `smt.and`, `smt.implies`, `smt.xor`, `smt.distinc`, `smt.eq`, and `smt.ite` and adds a new test for `smt.ite`.

Should I add more tests? With only booleans, there is only so much you can do.