### PR TITLE
fix bug in cannonicalization pass of smt dialect on `IteOp`

### DIFF
--- a/xdsl_smt/passes/canonicalization_patterns/smt.py
+++ b/xdsl_smt/passes/canonicalization_patterns/smt.py
@@ -261,7 +261,7 @@ class IteMergePattern(RewritePattern):
                 not_cond2_op = smt.NotOp.get(true_ite.cond)
                 new_cond_op = smt.AndOp.get(op.cond, not_cond2_op.res)
                 new_ite_op = smt.IteOp(
-                    new_cond_op.res, op.false_val, true_ite.false_val
+                    new_cond_op.res, true_ite.false_val, op.false_val
                 )
                 rewriter.replace_matched_op([not_cond2_op, new_cond_op, new_ite_op])
                 return


### PR DESCRIPTION
There is a bug in a canonicalization pass in the smt dialect, specifically in the `IteMergePattern`. This code in question claims to do this rewrite: `((x if c else y) if c' else x) -> y if c' && !c else x` (comment on line 259), but instead it actually did this one: `((x if c else y) if c' else x) -> `(x if c' && !c else y)`. 

This has lead to some smt queries giving different results depending on whether canonicalization has been called.