### PR TITLE
fix bugs in the smt cannonicalazion passes for sdiv and srem

### DIFF
--- a/tests/filecheck/canonicalize-smt/sdiv.mlir
+++ b/tests/filecheck/canonicalize-smt/sdiv.mlir
@@ -6,8 +6,10 @@
   %zero = smt.bv.constant #smt.bv<0> : !smt.bv<8>
   %five = smt.bv.constant #smt.bv<5> : !smt.bv<8>
   %c13 = smt.bv.constant #smt.bv<13> : !smt.bv<8>
+  %m1 = smt.bv.constant #smt.bv<255> : !smt.bv<8>
   %m5 = smt.bv.constant #smt.bv<251> : !smt.bv<8>
   %m13 = smt.bv.constant #smt.bv<243> : !smt.bv<8>
+  %int_min = smt.bv.constant #smt.bv<128> : !smt.bv<8>
 
   // Case 1: x sdiv 5  ==>  unchanged (rhs not zero, lhs not constant)
   %a = "smt.bv.sdiv"(%x, %five) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bv<8>
@@ -77,4 +79,14 @@
   // CHECK-NEXT: %h = smt.bv.constant #smt.bv<1> : !smt.bv<8>
   // CHECK-NEXT: %h_eq = "smt.eq"(%h, %y) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
   // CHECK-NEXT: "smt.assert"(%h_eq) : (!smt.bool) -> ()
+
+  // sdiv underflow semantics
+
+  // Case 9: int_min sdiv -1  ==> int_min
+  %i = "smt.bv.sdiv"(%int_min, %m1) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bv<8>
+  %i_eq = "smt.eq"(%i, %x) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  "smt.assert"(%i_eq) : (!smt.bool) -> ()
+  // CHECK-NEXT: %i = smt.bv.constant #smt.bv<128> : !smt.bv<8>
+  // CHECK-NEXT: %i_eq = "smt.eq"(%i, %x) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  // CHECK-NEXT: "smt.assert"(%i_eq) : (!smt.bool) -> ()
 }) : () -> ()

--- a/tests/filecheck/canonicalize-smt/sdiv.mlir
+++ b/tests/filecheck/canonicalize-smt/sdiv.mlir
@@ -1,0 +1,80 @@
+// RUN: xdsl-smt "%s" -p=canonicalize,dce | filecheck "%s"
+
+"builtin.module"() ({
+  %x = "smt.declare_const"() : () -> !smt.bv<8>
+  %y = "smt.declare_const"() : () -> !smt.bv<8>
+  %zero = smt.bv.constant #smt.bv<0> : !smt.bv<8>
+  %five = smt.bv.constant #smt.bv<5> : !smt.bv<8>
+  %c13 = smt.bv.constant #smt.bv<13> : !smt.bv<8>
+  %m5 = smt.bv.constant #smt.bv<251> : !smt.bv<8>
+  %m13 = smt.bv.constant #smt.bv<243> : !smt.bv<8>
+
+  // Case 1: x sdiv 5  ==>  unchanged (rhs not zero, lhs not constant)
+  %a = "smt.bv.sdiv"(%x, %five) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bv<8>
+  %a_eq = "smt.eq"(%a, %y) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  "smt.assert"(%a_eq) : (!smt.bool) -> ()
+  // CHECK: %a = "smt.bv.sdiv"(%x, %five) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bv<8>
+  // CHECK-NEXT: %a_eq = "smt.eq"(%a, %y) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  // CHECK-NEXT: "smt.assert"(%a_eq) : (!smt.bool) -> ()
+
+  // Case 2: x sdiv y  ==>  unchanged (rhs not a constant)
+  %b = "smt.bv.sdiv"(%x, %y) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bv<8>
+  %b_eq = "smt.eq"(%b, %five) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  "smt.assert"(%b_eq) : (!smt.bool) -> ()
+  // CHECK-NEXT: %b = "smt.bv.sdiv"(%x, %y) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bv<8>
+  // CHECK-NEXT: %b_eq = "smt.eq"(%b, %five) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  // CHECK-NEXT: "smt.assert"(%b_eq) : (!smt.bool) -> ()
+
+  // -------- Constant folding (both operands constant) --------
+
+  // Case 3: 13 sdiv 5  ==>  2  (folds)
+  %c = "smt.bv.sdiv"(%c13, %five) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bv<8>
+  %c_eq = "smt.eq"(%c, %x) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  "smt.assert"(%c_eq) : (!smt.bool) -> ()
+  // CHECK-NEXT: %c = smt.bv.constant #smt.bv<2> : !smt.bv<8>
+  // CHECK-NEXT: %c_eq = "smt.eq"(%c, %x) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  // CHECK-NEXT: "smt.assert"(%c_eq) : (!smt.bool) -> ()
+
+  // Case 4 (negative lhs): -13 sdiv 5  ==>  -2 (254 as 8-bit)  (folds)
+  %d = "smt.bv.sdiv"(%m13, %five) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bv<8>
+  %d_eq = "smt.eq"(%d, %y) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  "smt.assert"(%d_eq) : (!smt.bool) -> ()
+  // CHECK-NEXT: %d = smt.bv.constant #smt.bv<254> : !smt.bv<8>
+  // CHECK-NEXT: %d_eq = "smt.eq"(%d, %y) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  // CHECK-NEXT: "smt.assert"(%d_eq) : (!smt.bool) -> ()
+
+  // Case 5 (negative rhs): 13 sdiv -5  ==>  -2 (254 as 8-bit)  (folds)
+  %e = "smt.bv.sdiv"(%c13, %m5) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bv<8>
+  %e_eq = "smt.eq"(%e, %x) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  "smt.assert"(%e_eq) : (!smt.bool) -> ()
+  // CHECK-NEXT: %e = smt.bv.constant #smt.bv<254> : !smt.bv<8>
+  // CHECK-NEXT: %e_eq = "smt.eq"(%e, %x) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  // CHECK-NEXT: "smt.assert"(%e_eq) : (!smt.bool) -> ()
+
+  // Case 6 (both negative): -13 sdiv -5  ==>  2  (folds)
+  %f = "smt.bv.sdiv"(%m13, %m5) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bv<8>
+  %f_eq = "smt.eq"(%f, %y) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  "smt.assert"(%f_eq) : (!smt.bool) -> ()
+  // CHECK-NEXT: %f = smt.bv.constant #smt.bv<2> : !smt.bv<8>
+  // CHECK-NEXT: %f_eq = "smt.eq"(%f, %y) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  // CHECK-NEXT: "smt.assert"(%f_eq) : (!smt.bool) -> ()
+
+  // -------- Division by zero semantics (both operands constant) --------
+  // If rhs is 0: result is 255 when lhs is positive, and 1 otherwise.
+
+  // Case 7: 13 sdiv 0  ==>  255  (folds)
+  %g = "smt.bv.sdiv"(%c13, %zero) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bv<8>
+  %g_eq = "smt.eq"(%g, %x) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  "smt.assert"(%g_eq) : (!smt.bool) -> ()
+  // CHECK-NEXT: %g = smt.bv.constant #smt.bv<255> : !smt.bv<8>
+  // CHECK-NEXT: %g_eq = "smt.eq"(%g, %x) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  // CHECK-NEXT: "smt.assert"(%g_eq) : (!smt.bool) -> ()
+
+  // Case 8: -13 sdiv 0  ==>  1  (folds)
+  %h = "smt.bv.sdiv"(%m13, %zero) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bv<8>
+  %h_eq = "smt.eq"(%h, %y) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  "smt.assert"(%h_eq) : (!smt.bool) -> ()
+  // CHECK-NEXT: %h = smt.bv.constant #smt.bv<1> : !smt.bv<8>
+  // CHECK-NEXT: %h_eq = "smt.eq"(%h, %y) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  // CHECK-NEXT: "smt.assert"(%h_eq) : (!smt.bool) -> ()
+}) : () -> ()

--- a/tests/filecheck/canonicalize-smt/srem.mlir
+++ b/tests/filecheck/canonicalize-smt/srem.mlir
@@ -81,4 +81,3 @@
   // CHECK-NEXT: %i_eq = "smt.eq"(%i, %y) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
   // CHECK-NEXT: "smt.assert"(%i_eq) : (!smt.bool) -> ()
 }) : () -> ()
-

--- a/tests/filecheck/canonicalize-smt/srem.mlir
+++ b/tests/filecheck/canonicalize-smt/srem.mlir
@@ -1,0 +1,84 @@
+// RUN: xdsl-smt "%s" -p=canonicalize,dce | filecheck "%s"
+
+"builtin.module"() ({
+  %x = "smt.declare_const"() : () -> !smt.bv<8>
+  %y = "smt.declare_const"() : () -> !smt.bv<8>
+  %zero = smt.bv.constant #smt.bv<0> : !smt.bv<8>
+  %five = smt.bv.constant #smt.bv<5> : !smt.bv<8>
+  %c13 = smt.bv.constant #smt.bv<13> : !smt.bv<8>
+  %cneg5 = smt.bv.constant #smt.bv<251> : !smt.bv<8>
+  %cneg13 = smt.bv.constant #smt.bv<243> : !smt.bv<8>
+
+  // Case 1: x srem 0  ==>  x     (folds to x)
+  %a = "smt.bv.srem"(%x, %zero) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bv<8>
+  %a_eq = "smt.eq"(%a, %y) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  "smt.assert"(%a_eq) : (!smt.bool) -> ()
+  // CHECK: %a_eq = "smt.eq"(%x, %y) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  // CHECK-NEXT: "smt.assert"(%a_eq) : (!smt.bool) -> ()
+
+  // Case 2: x srem 5  ==>  unchanged (rhs not zero, should NOT fold)
+  %b = "smt.bv.srem"(%x, %five) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bv<8>
+  %b_eq = "smt.eq"(%b, %y) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  "smt.assert"(%b_eq) : (!smt.bool) -> ()
+  // CHECK-NEXT: %b = "smt.bv.srem"(%x, %five) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bv<8>
+  // CHECK-NEXT: %b_eq = "smt.eq"(%b, %y) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  // CHECK-NEXT: "smt.assert"(%b_eq) : (!smt.bool) -> ()
+
+  // Case 3: x srem y  ==>  unchanged (rhs not a constant, should NOT fold)
+  %c = "smt.bv.srem"(%x, %y) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bv<8>
+  %c_eq = "smt.eq"(%c, %five) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  "smt.assert"(%c_eq) : (!smt.bool) -> ()
+  // CHECK-NEXT: %c = "smt.bv.srem"(%x, %y) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bv<8>
+  // CHECK-NEXT: %c_eq = "smt.eq"(%c, %five) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  // CHECK-NEXT: "smt.assert"(%c_eq) : (!smt.bool) -> ()
+
+  // Case 4: 0 srem 0  ==>  0   (folds to LHS operand, which is %zero)
+  %d = "smt.bv.srem"(%zero, %zero) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bv<8>
+  %d_eq = "smt.eq"(%d, %x) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  "smt.assert"(%d_eq) : (!smt.bool) -> ()
+  // CHECK-NEXT: %d_eq = "smt.eq"(%zero, %x) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  // CHECK-NEXT: "smt.assert"(%d_eq) : (!smt.bool) -> ()
+
+  // Case 5: const srem const  ==>  const result (13 srem 5 = 3)
+  %e = "smt.bv.srem"(%c13, %five) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bv<8>
+  %e_eq = "smt.eq"(%e, %x) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  "smt.assert"(%e_eq) : (!smt.bool) -> ()
+  // CHECK-NEXT: %e = smt.bv.constant #smt.bv<3> : !smt.bv<8>
+  // CHECK-NEXT: %e_eq = "smt.eq"(%e, %x) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  // CHECK-NEXT: "smt.assert"(%e_eq) : (!smt.bool) -> ()
+
+  // ---- Signed-specific cases with negative operands ----
+
+  // Case 6: (-13) srem 5  ==>  2
+  %f = "smt.bv.srem"(%cneg13, %five) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bv<8>
+  %f_eq = "smt.eq"(%f, %x) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  "smt.assert"(%f_eq) : (!smt.bool) -> ()
+  // CHECK-NEXT: %f = smt.bv.constant #smt.bv<2> : !smt.bv<8>
+  // CHECK-NEXT: %f_eq = "smt.eq"(%f, %x) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  // CHECK-NEXT: "smt.assert"(%f_eq) : (!smt.bool) -> ()
+
+  // Case 7: 13 srem (-5)  ==>  -2
+  %g = "smt.bv.srem"(%c13, %cneg5) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bv<8>
+  %g_eq = "smt.eq"(%g, %x) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  "smt.assert"(%g_eq) : (!smt.bool) -> ()
+  // CHECK-NEXT: %g = smt.bv.constant #smt.bv<254> : !smt.bv<8>
+  // CHECK-NEXT: %g_eq = "smt.eq"(%g, %x) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  // CHECK-NEXT: "smt.assert"(%g_eq) : (!smt.bool) -> ()
+
+  // Case 8: (-13) srem (-5)  ==>  -3
+  %h = "smt.bv.srem"(%cneg13, %cneg5) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bv<8>
+  %h_eq = "smt.eq"(%h, %x) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool // arbitrary eq to keep %h used
+  "smt.assert"(%h_eq) : (!smt.bool) -> ()
+  // CHECK-NEXT: %h = smt.bv.constant #smt.bv<253> : !smt.bv<8>
+  // CHECK-NEXT: %h_eq = "smt.eq"(%h, %x) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  // CHECK-NEXT: "smt.assert"(%h_eq) : (!smt.bool) -> ()
+
+  // Case 9: x srem (-5)  ==>  unchanged (non-zero constant rhs, should NOT fold)
+  %i = "smt.bv.srem"(%x, %cneg5) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bv<8>
+  %i_eq = "smt.eq"(%i, %y) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  "smt.assert"(%i_eq) : (!smt.bool) -> ()
+  // CHECK-NEXT: %i = "smt.bv.srem"(%x, %cneg5) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bv<8>
+  // CHECK-NEXT: %i_eq = "smt.eq"(%i, %y) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  // CHECK-NEXT: "smt.assert"(%i_eq) : (!smt.bool) -> ()
+}) : () -> ()
+

--- a/tests/filecheck/canonicalize-smt/udiv.mlir
+++ b/tests/filecheck/canonicalize-smt/udiv.mlir
@@ -1,0 +1,49 @@
+// RUN: xdsl-smt "%s" -p=canonicalize,dce | filecheck "%s"
+
+"builtin.module"() ({
+  %x = "smt.declare_const"() : () -> !smt.bv<8>
+  %y = "smt.declare_const"() : () -> !smt.bv<8>
+  %zero = smt.bv.constant #smt.bv<0> : !smt.bv<8>
+  %five = smt.bv.constant #smt.bv<5> : !smt.bv<8>
+  %c13 = smt.bv.constant #smt.bv<13> : !smt.bv<8>
+
+  // Case 1: x udiv 0  ==>  255 (division-by-zero folds to 255)
+  %a = "smt.bv.udiv"(%x, %zero) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bv<8>
+  %a_eq = "smt.eq"(%a, %y) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  "smt.assert"(%a_eq) : (!smt.bool) -> ()
+  // CHECK: %a = smt.bv.constant #smt.bv<255> : !smt.bv<8>
+  // CHECK-NEXT: %a_eq = "smt.eq"(%a, %y) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  // CHECK-NEXT: "smt.assert"(%a_eq) : (!smt.bool) -> ()
+
+  // Case 2: x udiv 5  ==>  unchanged (rhs non-zero constant so no fold)
+  %b = "smt.bv.udiv"(%x, %five) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bv<8>
+  %b_eq = "smt.eq"(%b, %y) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  "smt.assert"(%b_eq) : (!smt.bool) -> ()
+  // CHECK-NEXT: %b = "smt.bv.udiv"(%x, %five) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bv<8>
+  // CHECK-NEXT: %b_eq = "smt.eq"(%b, %y) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  // CHECK-NEXT: "smt.assert"(%b_eq) : (!smt.bool) -> ()
+
+  // Case 3: x udiv y  ==>  unchanged (rhs not a constant so no fold)
+  %c = "smt.bv.udiv"(%x, %y) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bv<8>
+  %c_eq = "smt.eq"(%c, %five) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  "smt.assert"(%c_eq) : (!smt.bool) -> ()
+  // CHECK-NEXT: %c = "smt.bv.udiv"(%x, %y) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bv<8>
+  // CHECK-NEXT: %c_eq = "smt.eq"(%c, %five) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  // CHECK-NEXT: "smt.assert"(%c_eq) : (!smt.bool) -> ()
+
+  // Case 4: 0 udiv 0  ==>  255 (division-by-zero folds to 255)
+  %d = "smt.bv.udiv"(%zero, %zero) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bv<8>
+  %d_eq = "smt.eq"(%d, %x) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  "smt.assert"(%d_eq) : (!smt.bool) -> ()
+  // CHECK-NEXT: %d = smt.bv.constant #smt.bv<255> : !smt.bv<8>
+  // CHECK-NEXT: %d_eq = "smt.eq"(%d, %x) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  // CHECK-NEXT: "smt.assert"(%d_eq) : (!smt.bool) -> ()
+
+  // Case 5: const udiv const  ==>  const result (13 udiv 5 = 2)
+  %e = "smt.bv.udiv"(%c13, %five) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bv<8>
+  %e_eq = "smt.eq"(%e, %x) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  "smt.assert"(%e_eq) : (!smt.bool) -> ()
+  // CHECK-NEXT: %e = smt.bv.constant #smt.bv<2> : !smt.bv<8>
+  // CHECK-NEXT: %e_eq = "smt.eq"(%e, %x) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  // CHECK-NEXT: "smt.assert"(%e_eq) : (!smt.bool) -> ()
+}) : () -> ()

--- a/tests/filecheck/canonicalize-smt/urem.mlir
+++ b/tests/filecheck/canonicalize-smt/urem.mlir
@@ -1,0 +1,47 @@
+// RUN: xdsl-smt "%s" -p=canonicalize,dce | filecheck "%s"
+
+"builtin.module"() ({
+  %x = "smt.declare_const"() : () -> !smt.bv<8>
+  %y = "smt.declare_const"() : () -> !smt.bv<8>
+  %zero = smt.bv.constant #smt.bv<0> : !smt.bv<8>
+  %five = smt.bv.constant #smt.bv<5> : !smt.bv<8>
+  %c13 = smt.bv.constant #smt.bv<13> : !smt.bv<8>
+
+  // Case 1: x urem 0  ==>  x     (folds to x)
+  %a = "smt.bv.urem"(%x, %zero) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bv<8>
+  %a_eq = "smt.eq"(%a, %y) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  "smt.assert"(%a_eq) : (!smt.bool) -> ()
+  // CHECK: %a_eq = "smt.eq"(%x, %y) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  // CHECK-NEXT: "smt.assert"(%a_eq) : (!smt.bool) -> ()
+
+  // Case 2: x urem 5  ==>  unchanged (rhs not zero, should NOT fold)
+  %b = "smt.bv.urem"(%x, %five) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bv<8>
+  %b_eq = "smt.eq"(%b, %y) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  "smt.assert"(%b_eq) : (!smt.bool) -> ()
+  // CHECK-NEXT: %b = "smt.bv.urem"(%x, %five) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bv<8>
+  // CHECK-NEXT: %b_eq = "smt.eq"(%b, %y) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  // CHECK-NEXT: "smt.assert"(%b_eq) : (!smt.bool) -> ()
+
+  // Case 3: x urem y  ==>  unchanged (rhs not a constant, should NOT fold)
+  %c = "smt.bv.urem"(%x, %y) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bv<8>
+  %c_eq = "smt.eq"(%c, %five) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  "smt.assert"(%c_eq) : (!smt.bool) -> ()
+  // CHECK-NEXT: %c = "smt.bv.urem"(%x, %y) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bv<8>
+  // CHECK-NEXT: %c_eq = "smt.eq"(%c, %five) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  // CHECK-NEXT: "smt.assert"(%c_eq) : (!smt.bool) -> ()
+
+  // Case 4: 0 urem 0  ==>  0   (folds to LHS operand, which is %zero)
+  %d = "smt.bv.urem"(%zero, %zero) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bv<8>
+  %d_eq = "smt.eq"(%d, %x) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  "smt.assert"(%d_eq) : (!smt.bool) -> ()
+  // CHECK-NEXT: %d_eq = "smt.eq"(%zero, %x) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  // CHECK-NEXT: "smt.assert"(%d_eq) : (!smt.bool) -> ()
+
+  // Case 5: const urem const  ==>  const result (13 urem 5 = 3)
+  %e = "smt.bv.urem"(%c13, %five) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bv<8>
+  %e_eq = "smt.eq"(%e, %x) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  "smt.assert"(%e_eq) : (!smt.bool) -> ()
+  // CHECK-NEXT: %e = smt.bv.constant #smt.bv<3> : !smt.bv<8>
+  // CHECK-NEXT: %e_eq = "smt.eq"(%e, %x) : (!smt.bv<8>, !smt.bv<8>) -> !smt.bool
+  // CHECK-NEXT: "smt.assert"(%e_eq) : (!smt.bool) -> ()
+}) : () -> ()

--- a/xdsl_smt/dialects/smt_bitvector_dialect.py
+++ b/xdsl_smt/dialects/smt_bitvector_dialect.py
@@ -207,9 +207,19 @@ class MulOp(BinaryBVOp, SimpleSMTLibOp):
         return "bvmul"
 
 
+class URemCanonicalizationPatterns(HasCanonicalizationPatternsTrait):
+    @classmethod
+    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+        from xdsl_smt.passes.canonicalization_patterns.smt_bv import URemFold
+
+        return (URemFold(),)
+
+
 @irdl_op_definition
 class URemOp(BinaryBVOp, SimpleSMTLibOp):
     name = "smt.bv.urem"
+
+    traits = traits_def(traits.Pure(), URemCanonicalizationPatterns())
 
     def op_name(self) -> str:
         return "bvurem"
@@ -218,9 +228,7 @@ class URemOp(BinaryBVOp, SimpleSMTLibOp):
 class SRemCanonicalizationPatterns(HasCanonicalizationPatternsTrait):
     @classmethod
     def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
-        from xdsl_smt.passes.canonicalization_patterns.smt_bv import (
-            SRemFold,
-        )
+        from xdsl_smt.passes.canonicalization_patterns.smt_bv import SRemFold
 
         return (SRemFold(),)
 
@@ -270,9 +278,7 @@ class AShrOp(BinaryBVOp, SimpleSMTLibOp):
 class SDivCanonicalizationPatterns(HasCanonicalizationPatternsTrait):
     @classmethod
     def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
-        from xdsl_smt.passes.canonicalization_patterns.smt_bv import (
-            SDivFold,
-        )
+        from xdsl_smt.passes.canonicalization_patterns.smt_bv import SDivFold
 
         return (SDivFold(),)
 
@@ -287,9 +293,19 @@ class SDivOp(BinaryBVOp, SimpleSMTLibOp):
         return "bvsdiv"
 
 
+class UDivCanonicalizationPatterns(HasCanonicalizationPatternsTrait):
+    @classmethod
+    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+        from xdsl_smt.passes.canonicalization_patterns.smt_bv import UDivFold
+
+        return (UDivFold(),)
+
+
 @irdl_op_definition
 class UDivOp(BinaryBVOp, SimpleSMTLibOp):
     name = "smt.bv.udiv"
+
+    traits = traits_def(traits.Pure(), UDivCanonicalizationPatterns())
 
     def op_name(self) -> str:
         return "bvudiv"

--- a/xdsl_smt/passes/canonicalization_patterns/smt_bv.py
+++ b/xdsl_smt/passes/canonicalization_patterns/smt_bv.py
@@ -156,15 +156,14 @@ class SDivFold(RewritePattern):
 class URemFold(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: smt_bv.URemOp, rewriter: PatternRewriter):
-        # return
         # Check if rhs is constant
         rhs = get_bv_constant(op.rhs)
         if rhs is None:
             return
 
         # A remainder by zero should return the lhs value
-        if rhs == 0 and isinstance(op.lhs, OpResult):
-            rewriter.replace_matched_op(op.lhs.op.clone())
+        if rhs == 0:
+            rewriter.replace_matched_op([], [op.lhs])
             return
 
         # Check if lhs is constant
@@ -180,7 +179,6 @@ class URemFold(RewritePattern):
 class SRemFold(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: smt_bv.SRemOp, rewriter: PatternRewriter):
-        # Get the result width
         assert isinstance(type := op.results[0].type, smt_bv.BitVectorType)
         width = type.width.data
 
@@ -192,8 +190,8 @@ class SRemFold(RewritePattern):
         rhs = unsigned_to_signed(rhs, width)
 
         # A remainder by zero should return the lhs value
-        if rhs == 0 and isinstance(op.lhs, OpResult):
-            rewriter.replace_matched_op(op.lhs.op.clone())
+        if rhs == 0:
+            rewriter.replace_matched_op([], [op.lhs])
             return
 
         # Check if lhs is constant

--- a/xdsl_smt/passes/canonicalization_patterns/smt_bv.py
+++ b/xdsl_smt/passes/canonicalization_patterns/smt_bv.py
@@ -27,6 +27,16 @@ def unsigned_to_signed(value: int, width: int) -> int:
     return value - (1 << width) if value >= (1 << (width - 1)) else value
 
 
+def get_min_signed_value(width: int) -> int:
+    "Return the minimum signed integer value for a given width as an unsigned int"
+    return 1 << (width - 1)
+
+
+def get_all_ones(width: int) -> int:
+    "Return the unsigned int representation of a bitvector of 1's at a given width."
+    return (1 << width) - 1
+
+
 def bv_folding_canonicalization_pattern(
     op_type: type[Operation], operator: Callable[[Sequence[int]], int]
 ) -> type[RewritePattern]:
@@ -78,6 +88,32 @@ XorCanonicalizationPattern = bv_folding_canonicalization_pattern(
 )
 
 
+class UDivFold(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: smt_bv.UDivOp, rewriter: PatternRewriter):
+        # Get the result width
+        assert isinstance(type := op.results[0].type, smt_bv.BitVectorType)
+        width = type.width.data
+
+        # Check if rhs is constant
+        rhs = get_bv_constant(op.rhs)
+        if rhs is None:
+            return
+
+        # Division by zero returns a bv of all ones
+        if rhs == 0:
+            all_ones_bv = get_all_ones(width)
+            rewriter.replace_matched_op(smt_bv.ConstantOp(all_ones_bv, type.width))
+            return
+
+        # Check if lhs is constant
+        lhs = get_bv_constant(op.lhs)
+        if lhs is None:
+            return
+
+        rewriter.replace_matched_op(smt_bv.ConstantOp(lhs // rhs, type.width))
+
+
 class SDivFold(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: smt_bv.SDivOp, rewriter: PatternRewriter):
@@ -94,9 +130,22 @@ class SDivFold(RewritePattern):
         lhs = unsigned_to_signed(lhs, width)
         rhs = unsigned_to_signed(rhs, width)
 
-        # Division by zero or overflow
-        if rhs == 0 or (lhs == -(2 ** (width - 1)) and rhs == -1):
-            rewriter.replace_matched_op(smt_bv.ConstantOp(0, type.width))
+        # Division by zero returns:
+        #   all ones if lhs is positve
+        #   one if lhs is negative
+        if rhs == 0:
+            if lhs >= 0:
+                all_ones_bv = get_all_ones(width)
+                rewriter.replace_matched_op(smt_bv.ConstantOp(all_ones_bv, type.width))
+                return
+            else:
+                rewriter.replace_matched_op(smt_bv.ConstantOp(1, type.width))
+                return
+
+        # An underflowing signed division should return the signed min value
+        if lhs == -(2 ** (width - 1)) and rhs == -1:
+            signed_min_val = get_min_signed_value(width)
+            rewriter.replace_matched_op(smt_bv.ConstantOp(signed_min_val, type.width))
             return
 
         value = lhs // rhs if lhs * rhs > 0 else (lhs + (-lhs % rhs)) // rhs
@@ -104,33 +153,57 @@ class SDivFold(RewritePattern):
         rewriter.replace_matched_op(smt_bv.ConstantOp(value, type.width))
 
 
+class URemFold(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: smt_bv.URemOp, rewriter: PatternRewriter):
+        # return
+        # Check if rhs is constant
+        rhs = get_bv_constant(op.rhs)
+        if rhs is None:
+            return
+
+        # A remainder by zero should return the lhs value
+        if rhs == 0 and isinstance(op.lhs, OpResult):
+            rewriter.replace_matched_op(op.lhs.op.clone())
+            return
+
+        # Check if lhs is constant
+        lhs = get_bv_constant(op.lhs)
+        if lhs is None:
+            return
+
+        assert isinstance(type := op.results[0].type, smt_bv.BitVectorType)
+
+        rewriter.replace_matched_op(smt_bv.ConstantOp(lhs % rhs, type.width))
+
+
 class SRemFold(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: smt_bv.SRemOp, rewriter: PatternRewriter):
-        # Check if all operands are constants
-        lhs = get_bv_constant(op.lhs)
-        rhs = get_bv_constant(op.rhs)
-        if lhs is None or rhs is None:
-            return
-
         # Get the result width
         assert isinstance(type := op.results[0].type, smt_bv.BitVectorType)
         width = type.width.data
 
-        lhs = unsigned_to_signed(lhs, width)
-        rhs = unsigned_to_signed(rhs, width)
-
-        # Remainder by zero or overflow
-        if rhs == 0 or (lhs == -(2 ** (width - 1)) and rhs == -1):
-            rewriter.replace_matched_op(smt_bv.ConstantOp(0, type.width))
+        # Check if rhs is constant
+        rhs = get_bv_constant(op.rhs)
+        if rhs is None:
             return
 
-        if lhs < 0 and rhs > 0 or lhs > 0 and rhs < 0:
-            value = (lhs % rhs) - rhs
-        else:
-            value = lhs % rhs
+        rhs = unsigned_to_signed(rhs, width)
 
-        value = wrap_value(value, width)
+        # A remainder by zero should return the lhs value
+        if rhs == 0 and isinstance(op.lhs, OpResult):
+            rewriter.replace_matched_op(op.lhs.op.clone())
+            return
+
+        # Check if lhs is constant
+        lhs = get_bv_constant(op.lhs)
+        if lhs is None:
+            return
+
+        lhs = unsigned_to_signed(lhs, width)
+
+        value = wrap_value(lhs % rhs, width)
         rewriter.replace_matched_op(smt_bv.ConstantOp(value, type.width))
 
 


### PR DESCRIPTION
There are few bugs in `SRemFold` and `SDivFold`. 
When the canonicalizer sees constants as operands for the SRem and SDiv operations, it tries to elide the instruction and instead just return the new constant itself, unfortunatly on the edge cases it doesn't actually match z3's semantics.

For SRem when the rhs is 0 then the result should always be the lhs.
For SDiv when there's an underflow it should return INT_MIN, and when there's a div by zero the result should either be one or neg one, depending on sign of lhs

I also took the liberty of adding passes for Udiv and URem.
Not sure if there are unit tests for this part of the codebase, but if so I'd like to add some if I could, just to be extra sure of everything 