### PR TITLE
Fix function generation in declare-fun

### DIFF
--- a/tests/filecheck/dialects/core-theory/ops.mlir
+++ b/tests/filecheck/dialects/core-theory/ops.mlir
@@ -79,6 +79,13 @@
   // CHECK-NEXT: (assert ({{.*}} true))
   // CHECK-NEXT: {{.*}})
 
+  %dec_fun = "smt.declare_fun"() () : () -> ((!smt.bool, !smt.bool) -> !smt.bool)
+  %dec_res = "smt.call"(%dec_fun, %true, %true) : ((!smt.bool,!smt.bool) -> !smt.bool, !smt.bool,!smt.bool) -> !smt.bool
+  "smt.assert"(%dec_res) : (!smt.bool) -> ()
+  // CHECK: (declare-fun {{.*}} (Bool Bool) Bool)
+  // CHECK-NEXT: (assert ({{.*}} true))
+  // CHECK-NEXT: {{.*}})
+
   %false = smt.constant false
   "smt.assert"(%false) : (!smt.bool) -> ()
   // CHECK-NEXT: (assert false)

--- a/xdsl_smt/dialects/smt_dialect.py
+++ b/xdsl_smt/dialects/smt_dialect.py
@@ -205,12 +205,12 @@ class DeclareFunOp(IRDLOperation, SMTLibScriptOp):
         print(f"{name} ", file=stream, end="")
 
         # Print the function arguments
+        print("(", file=stream, end="")
         for idx, typ in enumerate(self.func_type.inputs):
             if idx != 0:
                 print(" ", file=stream, end="")
-            print("(", file=stream, end="")
             ctx.print_sort_to_smtlib(typ, stream)
-            print(")", file=stream, end="")
+        print(")", file=stream, end="")
 
         # Print the function return type
         assert len(self.func_type.outputs.data) == 1


### PR DESCRIPTION
This PR fixes the SMT generation in `declare-fun`