### PR TITLE
Fix cpp translate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,6 @@ ignore = [
   "xdsl_smt/utils/z3_to_dialect.py",
   "xdsl_smt/utils/integer_to_z3.py",
   "xdsl_smt/passes/calculate_smt.py",
-  "xdsl_smt/passes/transfer_lower.py",
   "xdsl_smt/cli/xdsl_translate.py",
   "xdsl_smt/cli/transfer_smt_verifier.py",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ include = ["xdsl_smt", "tests"]
 ignore = [
   "xdsl_smt/utils/z3_to_dialect.py",
   "xdsl_smt/utils/integer_to_z3.py",
-  "xdsl_smt/utils/lower_utils.py",
   "xdsl_smt/passes/calculate_smt.py",
   "xdsl_smt/passes/transfer_lower.py",
   "xdsl_smt/cli/xdsl_translate.py",

--- a/xdsl_smt/cli/cpp_translate.py
+++ b/xdsl_smt/cli/cpp_translate.py
@@ -1,128 +1,68 @@
-#!/usr/bin/env python3
-
 import argparse
-from typing import cast
 import sys
+from pathlib import Path
 
 from xdsl.context import Context
-from xdsl.ir import Operation
+from xdsl.dialects.arith import Arith
+from xdsl.dialects.builtin import Builtin, ModuleOp
+from xdsl.dialects.func import Func, FuncOp
 from xdsl.parser import Parser
 
-from xdsl.dialects.arith import Arith
-from xdsl.dialects.func import Func
-from xdsl_smt.dialects.transfer import Transfer
 from xdsl_smt.dialects.llvm_dialect import LLVM
-from xdsl_smt.passes.transfer_lower import LowerToCpp, addDispatcher, addInductionOps
-from xdsl.dialects.func import FuncOp, ReturnOp
-from xdsl.dialects.builtin import (
-    Builtin,
-    ModuleOp,
-    IntegerAttr,
-    StringAttr,
-)
+from xdsl_smt.dialects.transfer import Transfer
+from xdsl_smt.passes.transfer_lower import LowerToCpp
 
 
-def register_all_arguments(arg_parser: argparse.ArgumentParser):
-    arg_parser.add_argument(
-        "transfer_functions", type=str, nargs="?", help="path to the transfer functions"
+def _register_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Translate MLIR code to C++")
+
+    parser.add_argument(
+        "-i",
+        "--input",
+        type=Path,
+        default=None,
+        help="Path to the input MLIR file (defaults to stdin if omitted).",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=None,
+        help="Path to the output MLIR file (defaults to stdout if omitted).",
     )
 
+    return parser.parse_args()
 
-def parse_file(ctx: Context, file: str | None) -> Operation:
-    if file is None:
-        f = sys.stdin
-        file = "<stdin>"
+
+def _parse_mlir_module(p: Path | None, ctx: Context) -> ModuleOp:
+    code = p.read_text() if p else sys.stdin.read()
+    fname = p.name if p else "<stdin>"
+    mod = Parser(ctx, code, fname).parse_op()
+
+    if isinstance(mod, ModuleOp):
+        return mod
+    elif isinstance(mod, FuncOp):
+        return ModuleOp([mod])
     else:
-        f = open(file)
-
-    parser = Parser(ctx, f.read(), file)
-    module = parser.parse_op()
-    return module
+        raise ValueError(f"mlir in '{fname}' is neither a ModuleOp, nor a FuncOp")
 
 
-def is_transfer_function(func: FuncOp) -> bool:
-    return "applied_to" in func.attributes
-
-
-def is_forward(func: FuncOp) -> bool:
-    if "is_forward" in func.attributes:
-        forward = func.attributes["is_forward"]
-        assert isinstance(forward, IntegerAttr)
-        return forward.value.data == 1
-    return False
-
-
-def getCounterexampleFunc(func: FuncOp) -> str | None:
-    if "soundness_counterexample" not in func.attributes:
-        return None
-    attr = func.attributes["soundness_counterexample"]
-    assert isinstance(attr, StringAttr)
-    return attr.data
-
-
-def checkFunctionValidity(func: FuncOp) -> bool:
-    if len(func.function_type.inputs) != len(func.args):
-        return False
-    for func_type_arg, arg in zip(func.function_type.inputs, func.args):
-        if func_type_arg != arg.type:
-            return False
-    return_op = func.body.block.last_op
-    if not (return_op is not None and isinstance(return_op, ReturnOp)):
-        return False
-    return return_op.operands[0].type == func.function_type.outputs.data[0]
-
-
-def main() -> None:
+def _get_ctx() -> Context:
     ctx = Context()
-    arg_parser = argparse.ArgumentParser()
-    register_all_arguments(arg_parser)
-    args = arg_parser.parse_args()
-
-    # Register all dialects
     ctx.load_dialect(Arith)
     ctx.load_dialect(Builtin)
     ctx.load_dialect(Func)
     ctx.load_dialect(Transfer)
     ctx.load_dialect(LLVM)
 
-    # Parse the files
-    module = parse_file(ctx, args.transfer_functions)
-    assert isinstance(module, ModuleOp)
-
-    allFuncMapping: dict[str, FuncOp] = {}
-    forward = False
-    counterexampleFuncs: set[str] = set()
-    with open("tmp.cpp", "w") as fout:
-        LowerToCpp.fout = fout
-        for func in module.ops:
-            if isinstance(func, FuncOp):
-                if is_transfer_function(func):
-                    forward |= is_transfer_function(func) and is_forward(func)
-                    counterexampleFunc = getCounterexampleFunc(func)
-                    if counterexampleFunc is not None:
-                        counterexampleFuncs.add(counterexampleFunc)
-                allFuncMapping[func.sym_name.data] = func
-
-                # check function validity
-                if not checkFunctionValidity(func):
-                    print(func.sym_name)
-                # check function validity
-
-        for counterexample in counterexampleFuncs:
-            assert counterexample in allFuncMapping
-            allFuncMapping[counterexample].detach()
-            del allFuncMapping[counterexample]
-        for func in module.ops:
-            if isinstance(func, FuncOp):
-                allFuncMapping[func.sym_name.data] = func
-                # HACK: we know the pass won't check that the operation is a module
-                LowerToCpp(fout).apply(ctx, cast(ModuleOp, func))
-        addInductionOps(fout)
-        addDispatcher(fout, forward)
-
-    # printer = Printer(target=Printer.Target.MLIR)
-    # printer.print_op(module)
+    return ctx
 
 
-if __name__ == "__main__":
-    main()
+def main() -> None:
+    args = _register_args()
+
+    ctx = _get_ctx()
+    funcs = _parse_mlir_module(args.input, ctx)
+    output = args.output.open("w", encoding="utf-8") if args.output else sys.stdout
+
+    LowerToCpp(output).apply(ctx, funcs)

--- a/xdsl_smt/dialects/transfer.py
+++ b/xdsl_smt/dialects/transfer.py
@@ -286,6 +286,15 @@ class UAddOverflowOp(PredicateOp):
 class SAddOverflowOp(PredicateOp):
     name = "transfer.sadd_overflow"
 
+@irdl_op_definition
+class USubOverflowOp(PredicateOp):
+    name = "transfer.usub_overflow"
+
+
+@irdl_op_definition
+class SSubOverflowOp(PredicateOp):
+    name = "transfer.ssub_overflow"
+
 
 @irdl_op_definition
 class AndOp(BinOp):
@@ -829,6 +838,8 @@ Transfer = Dialect(
         SAddOverflowOp,
         UShlOverflowOp,
         SShlOverflowOp,
+        USubOverflowOp,
+        SSubOverflowOp,
         SelectOp,
         IsPowerOf2Op,
         IsAllOnesOp,

--- a/xdsl_smt/dialects/transfer.py
+++ b/xdsl_smt/dialects/transfer.py
@@ -31,7 +31,7 @@ from xdsl.irdl import (
     VarOperand,
     irdl_attr_definition,
     irdl_op_definition,
-    param_def,
+    ParameterDef,
     IRDLOperation,
     traits_def,
     lazy_traits_def,
@@ -285,6 +285,7 @@ class UAddOverflowOp(PredicateOp):
 @irdl_op_definition
 class SAddOverflowOp(PredicateOp):
     name = "transfer.sadd_overflow"
+
 
 @irdl_op_definition
 class USubOverflowOp(PredicateOp):
@@ -545,7 +546,7 @@ class CmpOp(PredicateOp):
 @irdl_attr_definition
 class AbstractValueType(ParametrizedAttribute, TypeAttribute):
     name = "transfer.abs_value"
-    fields: ArrayAttr[Attribute] = param_def()
+    fields: ParameterDef[ArrayAttr[Attribute]]
 
     def get_num_fields(self) -> int:
         return len(self.fields.data)
@@ -556,13 +557,13 @@ class AbstractValueType(ParametrizedAttribute, TypeAttribute):
     def __init__(self, shape: list[Attribute] | ArrayAttr[Attribute]) -> None:
         if isinstance(shape, list):
             shape = ArrayAttr(shape)
-        super().__init__(shape)
+        super().__init__([shape])
 
 
 @irdl_attr_definition
 class TupleType(ParametrizedAttribute, TypeAttribute):
     name = "transfer.tuple"
-    fields: ArrayAttr[Attribute] = param_def()
+    fields: ParameterDef[ArrayAttr[Attribute]]
 
     def get_num_fields(self) -> int:
         return len(self.fields.data)
@@ -573,7 +574,7 @@ class TupleType(ParametrizedAttribute, TypeAttribute):
     def __init__(self, shape: list[Attribute] | ArrayAttr[Attribute]) -> None:
         if isinstance(shape, list):
             shape = ArrayAttr(shape)
-        super().__init__(shape)
+        super().__init__([shape])
 
 
 @irdl_op_definition
@@ -794,6 +795,11 @@ class GetSignedMinValueOp(UnaryOp):
     name = "transfer.get_signed_min_value"
 
 
+@irdl_op_definition
+class GetLimitedValueOp(BinOp):
+    name = "transfer.get_limited_value"
+
+
 Transfer = Dialect(
     "transfer",
     [
@@ -856,6 +862,7 @@ Transfer = Dialect(
         AddPoisonOp,
         RemovePoisonOp,
         ReverseBitsOp,
+        GetLimitedValueOp,
     ],
     [TransIntegerType, AbstractValueType, TupleType],
 )

--- a/xdsl_smt/passes/transfer_lower.py
+++ b/xdsl_smt/passes/transfer_lower.py
@@ -1,76 +1,79 @@
-from typing import TextIO
-from xdsl.dialects.func import *
-from xdsl.pattern_rewriter import *
-from functools import singledispatch
 from dataclasses import dataclass
-from xdsl.passes import ModulePass
+from functools import singledispatch
+from typing import TextIO
 
-from xdsl.ir import Operation
 from xdsl.context import Context
-from ..utils.lower_utils import (
-    lowerOperation,
-    CPP_CLASS_KEY,
-    lowerDispatcher,
-    INDUCTION_KEY,
-    lowerInductionOps,
+from xdsl.dialects.builtin import ModuleOp
+from xdsl.dialects.func import FuncOp
+from xdsl.ir import Operation
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    GreedyRewritePatternApplier,
+    PatternRewriter,
+    PatternRewriteWalker,
+    RewritePattern,
+    op_type_rewrite_pattern,
 )
 
-from xdsl.pattern_rewriter import (
-    RewritePattern,
-    PatternRewriter,
-    op_type_rewrite_pattern,
-    PatternRewriteWalker,
-    GreedyRewritePatternApplier,
+from ..utils.lower_utils import (
+    CPP_CLASS_KEY,
+    INDUCTION_KEY,
+    lowerDispatcher,
+    lowerInductionOps,
+    lowerOperation,
+    set_int_to_apint,
 )
-from xdsl.dialects import builtin
 
 autogen = 0
 
 
 @singledispatch
-def transferFunction(op, fout):
+def transferFunction(op: Operation, fout: TextIO):
     pass
 
 
-funcStr = ""
 indent = "\t"
+funcPrefix = 'extern "C" '
+funcStr = funcPrefix
 needDispatch: list[FuncOp] = []
 inductionOp: list[FuncOp] = []
 
 
 @transferFunction.register
-def _(op: Operation, fout):
+def _(op: Operation, fout: TextIO):
     global needDispatch
     global inductionOp
     if isinstance(op, ModuleOp):
         return
-        # print(lowerDispatcher(needDispatch))
-        # fout.write(lowerDispatcher(needDispatch))
     if len(op.results) > 0 and op.results[0].name_hint is None:
         global autogen
         op.results[0].name_hint = "autogen" + str(autogen)
         autogen += 1
+    if isinstance(op, FuncOp):
+        for arg in op.args:
+            if arg.name_hint is None:
+                arg.name_hint = "autogen" + str(autogen)
+                autogen += 1
+        if CPP_CLASS_KEY in op.attributes:
+            needDispatch.append(op)
+        if INDUCTION_KEY in op.attributes:
+            inductionOp.append(op)
     global funcStr
     funcStr += lowerOperation(op)
     parentOp = op.parent_op()
     if isinstance(parentOp, FuncOp) and parentOp.body.block.last_op == op:
         funcStr += "}\n"
         fout.write(funcStr)
-        funcStr = ""
-    if isinstance(op, FuncOp):
-        if CPP_CLASS_KEY in op.attributes:
-            needDispatch.append(op)
-        if INDUCTION_KEY in op.attributes:
-            inductionOp.append(op)
+        funcStr = funcPrefix
 
 
 @dataclass
 class LowerOperation(RewritePattern):
-    def __init__(self, fout):
+    def __init__(self, fout: TextIO):
         self.fout = fout
 
     @op_type_rewrite_pattern
-    def match_and_rewrite(self, op: Operation, rewriter: PatternRewriter):
+    def match_and_rewrite(self, op: Operation, _: PatternRewriter):
         transferFunction(op, self.fout)
 
 
@@ -83,20 +86,26 @@ def addInductionOps(fout: TextIO):
 def addDispatcher(fout: TextIO, is_forward: bool):
     global needDispatch
     if len(needDispatch) != 0:
-        # print(lowerDispatcher(needDispatch))
         fout.write(lowerDispatcher(needDispatch, is_forward))
 
 
 @dataclass(frozen=True)
 class LowerToCpp(ModulePass):
     name = "trans_lower"
-    fout: TextIO = None
+    fout: TextIO
+    int_to_apint: bool = False
 
-    def apply(self, ctx: Context, op: builtin.ModuleOp) -> None:
+    def apply(self, ctx: Context, op: ModuleOp) -> None:
+        global autogen
+        autogen = 0
+        set_int_to_apint(self.int_to_apint)
+        # We found PatternRewriteWalker skipped the op itself during iteration
+        # Do it manually on op
+        transferFunction(op, self.fout)
         walker = PatternRewriteWalker(
             GreedyRewritePatternApplier([LowerOperation(self.fout)]),
             walk_regions_first=False,
-            apply_recursively=True,
+            apply_recursively=False,
             walk_reverse=False,
         )
         walker.rewrite_module(op)

--- a/xdsl_smt/utils/lower_utils.py
+++ b/xdsl_smt/utils/lower_utils.py
@@ -187,7 +187,7 @@ unsignedReturnedType = {
 }
 
 int_to_apint = False
-use_custom_vec = True
+use_custom_vec = False
 EQ = " = "
 END = ";\n"
 IDNT = "\t"
@@ -818,22 +818,7 @@ def castToUnisgnedFromAPInt(operand: SSAValue | str) -> str:
 
 
 @lowerOperation.register
-def _(op: SetHighBitsOp):
-    return set_clear_bits(op)
-
-
-@lowerOperation.register
-def _(op: SetLowBitsOp):
-    return set_clear_bits(op)
-
-
-@lowerOperation.register
-def _(op: ClearHighBitsOp):
-    return set_clear_bits(op)
-
-
-@lowerOperation.register
-def _(op: ClearLowBitsOp):
+def _(op: SetHighBitsOp | SetLowBitsOp | ClearHighBitsOp | ClearLowBitsOp):
     return set_clear_bits(op)
 
 
@@ -862,12 +847,7 @@ def _(op: ClearSignBitOp):
 
 
 @lowerOperation.register
-def _(op: GetLowBitsOp):
-    return lowerToClassMethod(op, castToUnisgnedFromAPInt)
-
-
-@lowerOperation.register
-def _(op: GetHighBitsOp):
+def _(op: GetLowBitsOp | GetHighBitsOp):
     return lowerToClassMethod(op, castToUnisgnedFromAPInt)
 
 
@@ -877,22 +857,7 @@ def _(op: GetBitWidthOp):
 
 
 @lowerOperation.register
-def _(op: SMaxOp):
-    return lower_min_max(op)
-
-
-@lowerOperation.register
-def _(op: SMinOp):
-    return lower_min_max(op)
-
-
-@lowerOperation.register
-def _(op: UMaxOp):
-    return lower_min_max(op)
-
-
-@lowerOperation.register
-def _(op: UMinOp):
+def _(op: SMaxOp | SMinOp | UMaxOp | UMinOp):
     return lower_min_max(op)
 
 
@@ -908,22 +873,7 @@ def lower_min_max(op: UMinOp | UMaxOp | SMinOp | SMaxOp) -> str:
 
 
 @lowerOperation.register
-def _(op: ShlOp):
-    return lowerToClassMethod(op, castToUnisgnedFromAPInt)
-
-
-@lowerOperation.register
-def _(op: AShrOp):
-    return lowerToClassMethod(op, castToUnisgnedFromAPInt)
-
-
-@lowerOperation.register
-def _(op: LShrOp):
-    return lowerToClassMethod(op, castToUnisgnedFromAPInt)
-
-
-@lowerOperation.register
-def _(op: ExtractOp):
+def _(op: ShlOp | AShrOp | LShrOp | ExtractOp):
     return lowerToClassMethod(op, castToUnisgnedFromAPInt)
 
 

--- a/xdsl_smt/utils/lower_utils.py
+++ b/xdsl_smt/utils/lower_utils.py
@@ -1,52 +1,63 @@
+from functools import singledispatch
+from typing import Callable
+
+import xdsl.dialects.arith as arith
+from xdsl.dialects.builtin import IndexType, IntegerAttr, IntegerType
+from xdsl.dialects.func import CallOp, FuncOp, ReturnOp
+from xdsl.ir import Attribute, Block, BlockArgument, Operation, SSAValue
+
 from ..dialects.transfer import (
     AbstractValueType,
-    GetOp,
-    MakeOp,
-    NegOp,
-    Constant,
+    AddPoisonOp,
+    AShrOp,
+    ClearHighBitsOp,
+    ClearLowBitsOp,
+    ClearSignBitOp,
     CmpOp,
-    AndOp,
-    OrOp,
-    XorOp,
-    AddOp,
-    SubOp,
+    ConcatOp,
+    Constant,
+    ConstRangeForOp,
     CountLOneOp,
     CountLZeroOp,
     CountROneOp,
     CountRZeroOp,
+    ExtractOp,
+    GetAllOnesOp,
+    GetBitWidthOp,
+    GetHighBitsOp,
+    GetLowBitsOp,
+    GetOp,
+    GetSignedMaxValueOp,
+    GetSignedMinValueOp,
+    IntersectsOp,
+    LShrOp,
+    MakeOp,
+    NegOp,
+    NextLoopOp,
+    RemovePoisonOp,
+    RepeatOp,
+    SAddOverflowOp,
+    SDivOp,
+    SelectOp,
     SetHighBitsOp,
     SetLowBitsOp,
-    GetLowBitsOp,
-    GetBitWidthOp,
-    UMulOverflowOp,
-    SMinOp,
-    SMaxOp,
-    UMinOp,
-    UMaxOp,
-    TransIntegerType,
+    SetSignBitOp,
     ShlOp,
-    AShrOp,
-    LShrOp,
-    ExtractOp,
-    ConcatOp,
-    GetAllOnesOp,
-    SelectOp,
-    NextLoopOp,
-    ConstRangeForOp,
-    RepeatOp,
-    IntersectsOp,
-    # FromArithOp,
+    SMaxOp,
+    SMinOp,
+    SMulOverflowOp,
+    SRemOp,
+    SShlOverflowOp,
+    TransIntegerType,
     TupleType,
-    AddPoisonOp,
-    RemovePoisonOp,
+    UAddOverflowOp,
+    UDivOp,
+    UMaxOp,
+    UMinOp,
+    UMulOverflowOp,
+    URemOp,
+    UShlOverflowOp,
 )
-from xdsl.dialects.func import FuncOp, Return, Call
-from xdsl.pattern_rewriter import *
-from functools import singledispatch
-from typing import TypeVar, cast
-from xdsl.dialects.builtin import Signedness, IntegerType, IndexType, IntegerAttr
-from xdsl.ir import Operation
-import xdsl.dialects.arith as arith
 
 operNameToCpp = {
     "transfer.and": "&",
@@ -62,15 +73,29 @@ operNameToCpp = {
     "arith.subi": "-",
     "transfer.neg": "~",
     "transfer.mul": "*",
+    "transfer.udiv": ".udiv",
+    "transfer.sdiv": ".sdiv",
+    "transfer.urem": ".urem",
+    "transfer.srem": ".srem",
     "transfer.umul_overflow": ".umul_ov",
+    "transfer.smul_overflow": ".smul_ov",
+    "transfer.uadd_overflow": ".uadd_ov",
+    "transfer.sadd_overflow": ".sadd_ov",
+    "transfer.ushl_overflow": ".ushl_ov",
+    "transfer.sshl_overflow": ".sshl_ov",
     "transfer.get_bit_width": ".getBitWidth",
     "transfer.countl_zero": ".countl_zero",
     "transfer.countr_zero": ".countr_zero",
     "transfer.countl_one": ".countl_one",
     "transfer.countr_one": ".countr_one",
+    "transfer.get_high_bits": ".getHiBits",
     "transfer.get_low_bits": ".getLoBits",
     "transfer.set_high_bits": ".setHighBits",
     "transfer.set_low_bits": ".setLowBits",
+    "transfer.clear_high_bits": ".clearHighBits",
+    "transfer.clear_low_bits": ".clearLowBits",
+    "transfer.set_sign_bit": ".setSignBit",
+    "transfer.clear_sign_bit": ".clearSignBit",
     "transfer.intersects": ".intersects",
     "transfer.cmp": [
         ".eq",
@@ -84,7 +109,6 @@ operNameToCpp = {
         ".ugt",
         ".uge",
     ],
-    # "transfer.fromArith": "APInt",
     "transfer.make": "{{{0}}}",
     "transfer.get": "[{0}]",
     "transfer.shl": ".shl",
@@ -92,21 +116,67 @@ operNameToCpp = {
     "transfer.lshr": ".lshr",
     "transfer.concat": ".concat",
     "transfer.extract": ".extractBits",
-    "transfer.umin": [".ule", "?", ":"],
-    "transfer.smin": [".sle", "?", ":"],
-    "transfer.umax": [".ugt", "?", ":"],
-    "transfer.smax": [".sgt", "?", ":"],
+    "transfer.umin": "A::APIntOps::umin",
+    "transfer.smin": "A::APIntOps::smin",
+    "transfer.umax": "A::APIntOps::umax",
+    "transfer.smax": "A::APIntOps::smax",
     "func.return": "return",
     "transfer.constant": "APInt",
     "arith.select": ["?", ":"],
     "arith.cmpi": ["==", "!=", "<", "<=", ">", ">="],
     "transfer.get_all_ones": "APInt::getAllOnes",
+    "transfer.get_signed_max_value": "APInt::getSignedMaxValue",
+    "transfer.get_signed_min_value": "APInt::getSignedMinValue",
     "transfer.select": ["?", ":"],
     "transfer.reverse_bits": ".reverseBits",
     "transfer.add_poison": " ",
     "transfer.remove_poison": " ",
+    "comb.add": "+",
+    "comb.sub": "-",
+    "comb.mul": "*",
+    "comb.and": "&",
+    "comb.or": "|",
+    "comb.xor": "^",
+    "comb.divs": ".sdiv",
+    "comb.divu": ".udiv",
+    "comb.mods": ".srem",
+    "comb.modu": ".urem",
+    "comb.mux": ["?", ":"],
+    "comb.shrs": ".ashr",
+    "comb.shru": ".lshr",
+    "comb.shl": ".shl",
+    "comb.extract": ".extractBits",
+    "comb.concat": ".concat",
 }
 # transfer.constRangeLoop and NextLoop are controller operations, should be handle specially
+
+
+VAL_EXCEEDS_BW = "{1}.uge({1}.getBitWidth())"
+RHS_IS_ZERO = "{1} == 0"
+RET_ZERO = "{0} = APInt({1}.getBitWidth(), 0)"
+RET_ONE = "{0} = APInt({1}.getBitWidth(), 1)"
+RET_ONES = "{0} = APInt({1}.getBitWidth(), -1)"
+RET_SIGN_MIN_VAL = "{0} = APInt::getSignedMinValue({1}.getBitWidth())"
+RET_LHS = "{0} = {1}"
+
+SHIFT_ACTION = (VAL_EXCEEDS_BW, RET_ZERO)
+ASHR_ACTION0 = VAL_EXCEEDS_BW + " && {0}.isSignBitSet()", RET_ONES
+ASHR_ACTION1 = VAL_EXCEEDS_BW + " && {0}.isSignBitClear()", RET_ZERO
+REM_ACTION = RHS_IS_ZERO, RET_LHS
+DIV_ACTION = RHS_IS_ZERO, RET_ONES
+SDIV_ACTION0 = ("{0}.isMinSignedValue() && {1} == -1", RET_SIGN_MIN_VAL)
+SDIV_ACTION1 = (RHS_IS_ZERO + " && {0}.isNonNegative()", RET_ONES)
+SDIV_ACTION2 = (RHS_IS_ZERO + " && {0}.isNegative()", RET_ONE)
+
+op_to_cons: dict[type[Operation], list[tuple[str, str]]] = {
+    ShlOp: [SHIFT_ACTION],
+    LShrOp: [SHIFT_ACTION],
+    UDivOp: [DIV_ACTION],
+    URemOp: [REM_ACTION],
+    SRemOp: [REM_ACTION],
+    AShrOp: [ASHR_ACTION0, ASHR_ACTION1],
+    SDivOp: [SDIV_ACTION0, SDIV_ACTION1, SDIV_ACTION2],
+}
 
 unsignedReturnedType = {
     CountLOneOp,
@@ -116,11 +186,49 @@ unsignedReturnedType = {
     GetBitWidthOp,
 }
 
-ends = ";\n"
-indent = "\t"
+int_to_apint = False
+use_custom_vec = True
+EQ = " = "
+END = ";\n"
+IDNT = "\t"
+CPP_CLASS_KEY = "CPPCLASS"
+INDUCTION_KEY = "induction"
+OPERATION_NO = "operationNo"
 
 
-def lowerType(typ, specialOp=None):
+def set_int_to_apint(to_apint: bool) -> None:
+    global int_to_apint
+    int_to_apint = to_apint
+
+
+def set_use_custom_vec(custom_vec: bool) -> None:
+    global use_custom_vec
+    use_custom_vec = custom_vec
+
+
+def get_ret_val(op: Operation) -> str:
+    ret_val = op.results[0].name_hint
+    assert ret_val
+    return ret_val
+
+
+def get_op_names(op: Operation) -> list[str]:
+    return [oper.name_hint for oper in op.operands if oper.name_hint]
+
+
+def get_operand(op: Operation, idx: int) -> str:
+    name = op.operands[idx].name_hint
+    assert name
+    return name
+
+
+def get_op_str(op: Operation) -> str:
+    op_name = operNameToCpp[op.name]
+    assert isinstance(op_name, str)
+    return op_name
+
+
+def lowerType(typ: Attribute, specialOp: Operation | Block | None = None) -> str:
     if specialOp is not None:
         for op in unsignedReturnedType:
             if isinstance(specialOp, op):
@@ -132,20 +240,17 @@ def lowerType(typ, specialOp=None):
         typeName = lowerType(fields[0])
         for i in range(1, len(fields)):
             assert lowerType(fields[i]) == typeName
+        if use_custom_vec:
+            return "Vec<" + str(len(fields)) + ">"
         return "std::vector<" + typeName + ">"
     elif isinstance(typ, IntegerType):
-        return "int"
+        return "int" if not int_to_apint else "APInt"
     elif isinstance(typ, IndexType):
         return "int"
     assert False and "unsupported type"
 
 
-CPP_CLASS_KEY = "CPPCLASS"
-INDUCTION_KEY = "induction"
-OPERATION_NO = "operationNo"
-
-
-def lowerInductionOps(inductionOp: list[FuncOp]):
+def lowerInductionOps(inductionOp: list[FuncOp]) -> str:
     if len(inductionOp) > 0:
         functionSignature = """
 {returnedType} {funcName}(ArrayRef<{returnedType}> operands){{
@@ -159,16 +264,16 @@ def lowerInductionOps(inductionOp: list[FuncOp]):
 """
         result = ""
         for func in inductionOp:
-            returnedType = func.function_type.outputs.data[0]
             funcName = func.sym_name.data
-            returnedType = lowerType(returnedType)
-            result += functionSignature.format(
-                returnedType=returnedType, funcName=funcName
-            )
+            ret_ty = lowerType(func.function_type.outputs.data[0])
+            result += functionSignature.format(returnedType=ret_ty, funcName=funcName)
+
         return result
 
+    return ""
 
-def lowerDispatcher(needDispatch: list[FuncOp], is_forward: bool):
+
+def lowerDispatcher(needDispatch: list[FuncOp], is_forward: bool) -> str:
     if len(needDispatch) > 0:
         returnedType = needDispatch[0].function_type.outputs.data[0]
         for func in needDispatch:
@@ -190,18 +295,18 @@ def lowerDispatcher(needDispatch: list[FuncOp], is_forward: bool):
         functionSignature = (
             "std::optional<" + returnedType + "> " + funcName + expr + "{{\n{0}}}\n\n"
         )
-        indent = "\t"
+
         dyn_cast = (
-            indent
+            IDNT
             + "if(auto castedOp=dyn_cast<{0}>(op);castedOp&&{1}){{\n{2}"
-            + indent
+            + IDNT
             + "}}\n"
         )
-        return_inst = indent + indent + "return {0}({1});\n"
+        return_inst = IDNT + IDNT + "return {0}({1});\n"
 
         def handleOneTransferFunction(func: FuncOp, operationNo: int) -> str:
             blockStr = ""
-            for cppClass in func.attributes[CPP_CLASS_KEY]:
+            for cppClass in func.attributes[CPP_CLASS_KEY]:  # type: ignore
                 argStr = ""
                 if INDUCTION_KEY in func.attributes:
                     argStr = "operands"
@@ -215,95 +320,117 @@ def lowerDispatcher(needDispatch: list[FuncOp], is_forward: bool):
                     operationNoStr = "true"
                 else:
                     operationNoStr = "operationNo == " + str(operationNo)
-                blockStr += dyn_cast.format(cppClass.data, operationNoStr, ifBody)
+                blockStr += dyn_cast.format(cppClass.data, operationNoStr, ifBody)  # type: ignore
             return blockStr
 
         funcBody = ""
         for func in needDispatch:
             if is_forward:
-                funcBody += handleOneTransferFunction(func)
+                funcBody += handleOneTransferFunction(func, -1)
             else:
                 operationNo = func.attributes[OPERATION_NO]
                 assert isinstance(operationNo, IntegerAttr)
                 funcBody += handleOneTransferFunction(func, operationNo.value.data)
-        funcBody += indent + "return {};\n"
+        funcBody += IDNT + "return {};\n"
+
         return functionSignature.format(funcBody)
 
+    return ""
 
-def isFunctionCall(opName):
+
+def isFunctionCall(opName: str) -> bool:
     return opName[0] == "."
 
 
-def lowerToNonClassMethod(op: Operation):
-    returnedType = lowerType(op.results[0].type, op)
-    returnedValue = op.results[0].name_hint
-    equals = "="
+def lowerToNonClassMethod(op: Operation) -> str:
+    ret_type = lowerType(op.results[0].type, op)
+    ret_val = get_ret_val(op)
     expr = "("
     if len(op.operands) > 0:
-        expr += op.operands[0].name_hint
+        expr += get_operand(op, 0)
     for i in range(1, len(op.operands)):
-        expr += "," + op.operands[i].name_hint
+        expr += "," + get_operand(op, i)
     expr += ")"
-    return (
-        indent
-        + returnedType
-        + " "
-        + returnedValue
-        + equals
-        + operNameToCpp[op.name]
-        + expr
-        + ends
-    )
+
+    return IDNT + ret_type + " " + ret_val + EQ + get_op_str(op) + expr + END
 
 
-def lowerToClassMethod(op: Operation, castOperand=None, castResult=None):
-    returnedType = lowerType(op.results[0].type, op)
+def lowerToClassMethod(
+    op: Operation,
+    castOperand: Callable[[SSAValue | str], str] | None = None,
+    castResult: Callable[[Operation], str] | None = None,
+) -> str:
+    ret_ty = lowerType(op.results[0].type, op)
+    ret_val = get_ret_val(op)
+
     if castResult is not None:
-        returnedValue = op.results[0].name_hint + "_autocast"
-    else:
-        returnedValue = op.results[0].name_hint
-    equals = "="
-    expr = op.operands[0].name_hint + operNameToCpp[op.name] + "("
+        ret_val += "_autocast"
+    expr = get_operand(op, 0) + get_op_str(op) + "("
+
     if castOperand is not None:
         operands = [castOperand(operand) for operand in op.operands]
     else:
-        operands = [operand.name_hint for operand in op.operands]
+        operands = get_op_names(op)
+
     if len(operands) > 1:
         expr += operands[1]
     for i in range(2, len(operands)):
         expr += "," + operands[i]
+
     expr += ")"
-    result = indent + returnedType + " " + returnedValue + equals + expr + ends
+
+    if type(op) in op_to_cons:
+        conds, actions = zip(*op_to_cons[type(op)])  # type: ignore
+
+        og_op_names = get_op_names(op)
+        conds: list[str] = [cond.format(*og_op_names) for cond in conds]
+        actions: list[str] = [act.format(ret_val, *og_op_names) for act in actions]
+
+        if_fmt = "if ({cond}) {{\n" + IDNT + IDNT + "{act}" + END + IDNT + "}}"
+
+        ifs = " else ".join(
+            [if_fmt.format(cond=c, act=a) for c, a in zip(conds, actions)]
+        )
+
+        final_else_br = IDNT + IDNT + ret_val + EQ + expr + END
+
+        result = IDNT + ret_ty + " " + ret_val + END
+        result += IDNT + ifs + " else {\n" + final_else_br + IDNT + "}\n"
+
+    else:
+        result = IDNT + ret_ty + " " + ret_val + EQ + expr + END
+
     if castResult is not None:
         return result + castResult(op)
+
     return result
 
 
 @singledispatch
-def lowerOperation(op):
+def lowerOperation(op: Operation) -> str:
     returnedType = lowerType(op.results[0].type, op)
-    returnedValue = op.results[0].name_hint
-    equals = "="
-    operandsName = [oper.name_hint for oper in op.operands]
-    if isFunctionCall(operNameToCpp[op.name]):
-        expr = operandsName[0] + operNameToCpp[op.name] + "("
+    returnedValue = get_ret_val(op)
+    operandsName = get_op_names(op)
+    op_str = get_op_str(op)
+
+    if isFunctionCall(op_str):
+        expr = operandsName[0] + op_str + "("
         if len(operandsName) > 1:
             expr += operandsName[1]
         for i in range(2, len(operandsName)):
             expr += "," + operandsName[i]
         expr += ")"
     else:
-        expr = operandsName[0] + operNameToCpp[op.name] + operandsName[1]
-    result = indent + returnedType + " " + returnedValue + equals + expr + ends
-    return result
+        expr = operandsName[0] + op_str + operandsName[1]
+
+    return IDNT + returnedType + " " + returnedValue + EQ + expr + END
 
 
 @lowerOperation.register
 def _(op: CmpOp):
     returnedType = lowerType(op.results[0].type)
-    returnedValue = op.results[0].name_hint
-    equals = "="
-    operandsName = [oper.name_hint for oper in op.operands]
+    returnedValue = get_ret_val(op)
+    operandsName = get_op_names(op)
     predicate = op.predicate.value.data
     operName = operNameToCpp[op.name][predicate]
     expr = operandsName[0] + operName + "("
@@ -312,219 +439,291 @@ def _(op: CmpOp):
     for i in range(2, len(operandsName)):
         expr += "," + operandsName[i]
     expr += ")"
-    return indent + returnedType + " " + returnedValue + equals + expr + ends
+
+    return IDNT + returnedType + " " + returnedValue + EQ + expr + END
 
 
 @lowerOperation.register
-def _(op: arith.Cmpi):
+def _(op: arith.CmpiOp):
     returnedType = lowerType(op.results[0].type)
-    returnedValue = op.results[0].name_hint
-    equals = "="
-    operandsName = [oper.name_hint for oper in op.operands]
+    returnedValue = get_ret_val(op)
+    operandsName = get_op_names(op)
     assert len(operandsName) == 2
     predicate = op.predicate.value.data
     operName = operNameToCpp[op.name][predicate]
-    expr = "(" + operandsName[0] + operName + operandsName[1]
-    expr += ")"
-    return indent + returnedType + " " + returnedValue + equals + expr + ends
+    expr = "(" + operandsName[0] + operName + operandsName[1] + ")"
+
+    return IDNT + returnedType + " " + returnedValue + EQ + expr + END
 
 
 @lowerOperation.register
-def _(op: arith.Select):
+def _(op: arith.SelectOp):
     returnedType = lowerType(op.operands[1].type, op)
-    returnedValue = op.results[0].name_hint
-    equals = "="
-    operandsName = [oper.name_hint for oper in op.operands]
+    returnedValue = get_ret_val(op)
+    operandsName = get_op_names(op)
     operator = operNameToCpp[op.name]
     expr = ""
     for i in range(len(operandsName)):
         expr += operandsName[i] + " "
         if i < len(operator):
             expr += operator[i] + " "
-    return indent + returnedType + " " + returnedValue + equals + expr + ends
+
+    return IDNT + returnedType + " " + returnedValue + EQ + expr + END
 
 
 @lowerOperation.register
 def _(op: SelectOp):
     returnedType = lowerType(op.operands[1].type, op)
-    returnedValue = op.results[0].name_hint
-    equals = "="
-    operandsName = [oper.name_hint for oper in op.operands]
+    returnedValue = get_ret_val(op)
+    operandsName = get_op_names(op)
     operator = operNameToCpp[op.name]
     expr = ""
     for i in range(len(operandsName)):
         expr += operandsName[i] + " "
         if i < len(operator):
             expr += operator[i] + " "
-    return indent + returnedType + " " + returnedValue + equals + expr + ends
+
+    return IDNT + returnedType + " " + returnedValue + EQ + expr + END
 
 
 @lowerOperation.register
-def _(op: GetOp):
+def _(op: GetOp) -> str:
     returnedType = lowerType(op.results[0].type)
-    returnedValue = op.results[0].name_hint
-    equals = "="
-    index = op.attributes["index"].value.data
+    returnedValue = get_ret_val(op)
+    index = op.attributes["index"].value.data  # type: ignore
+
     return (
-        indent
+        IDNT
         + returnedType
         + " "
         + returnedValue
-        + equals
-        + op.operands[0].name_hint
-        + operNameToCpp[op.name].format(index)
-        + ends
+        + EQ
+        + get_operand(op, 0)
+        + get_op_str(op).format(index)  # type: ignore
+        + END
     )
 
 
 @lowerOperation.register
-def _(op: MakeOp):
+def _(op: MakeOp) -> str:
     returnedType = lowerType(op.results[0].type, op)
-    returnedValue = op.results[0].name_hint
-    equals = "="
+    returnedValue = get_ret_val(op)
     expr = ""
     if len(op.operands) > 0:
-        expr += op.operands[0].name_hint
+        expr += get_operand(op, 0)
     for i in range(1, len(op.operands)):
-        expr += "," + op.operands[i].name_hint
+        expr += "," + get_operand(op, i)
+
     return (
-        indent
+        IDNT
         + returnedType
         + " "
         + returnedValue
-        + equals
+        + EQ
         + returnedType
-        + operNameToCpp[op.name].format(expr)
-        + ends
+        + get_op_str(op).format(expr)
+        + END
     )
+
+
+def trivial_overflow_predicate(op: Operation) -> str:
+    returnedValue = get_ret_val(op)
+    varDecls = "bool " + returnedValue + END
+    expr = get_operand(op, 0) + get_op_str(op) + "("
+    expr += get_operand(op, 1) + "," + returnedValue + ")"
+    result = varDecls + IDNT + expr + END
+    return IDNT + result
 
 
 @lowerOperation.register
 def _(op: UMulOverflowOp):
-    varDecls = "bool " + op.results[0].name_hint + ends
-    expr = op.operands[0].name_hint + operNameToCpp[op.name] + "("
-    expr += op.operands[1].name_hint + "," + op.results[0].name_hint
-    expr += ")"
-    result = varDecls + "\t" + expr + ends
-    return indent + result
+    return trivial_overflow_predicate(op)
 
 
 @lowerOperation.register
-def _(op: NegOp):
-    returnedType = lowerType(op.results[0].type)
-    returnedValue = op.results[0].name_hint
-    equals = "="
-    return (
-        indent
-        + returnedType
-        + " "
-        + returnedValue
-        + equals
-        + operNameToCpp[op.name]
-        + op.operands[0].name_hint
-        + ends
-    )
+def _(op: SMulOverflowOp):
+    return trivial_overflow_predicate(op)
 
 
 @lowerOperation.register
-def _(op: Return):
-    opName = operNameToCpp[op.name] + " "
+def _(op: UAddOverflowOp):
+    return trivial_overflow_predicate(op)
+
+
+@lowerOperation.register
+def _(op: SAddOverflowOp):
+    return trivial_overflow_predicate(op)
+
+
+@lowerOperation.register
+def _(op: SShlOverflowOp):
+    return trivial_overflow_predicate(op)
+
+
+@lowerOperation.register
+def _(op: UShlOverflowOp):
+    return trivial_overflow_predicate(op)
+
+
+@lowerOperation.register
+def _(op: NegOp) -> str:
+    ret_type = lowerType(op.results[0].type)
+    ret_val = get_ret_val(op)
+    op_str = get_op_str(op)
+    operand = get_operand(op, 0)
+
+    return IDNT + ret_type + " " + ret_val + EQ + op_str + operand + END
+
+
+@lowerOperation.register
+def _(op: ReturnOp) -> str:
+    opName = get_op_str(op) + " "
     operand = op.arguments[0].name_hint
-    return indent + opName + operand + ends
+    assert operand
 
-
-"""
-@lowerOperation.register
-def _(op: FromArithOp):
-    opTy = op.op.type
-    assert isinstance(opTy, IntegerType)
-    size = opTy.width.data
-    returnedType = "APInt"
-    returnedValue = op.results[0].name_hint
-    return (
-        indent
-        + returnedType
-        + " "
-        + returnedValue
-        + "("
-        + str(size)
-        + ", "
-        + op.op.name_hint
-        + ")"
-        + ends
-    )
-"""
+    return IDNT + opName + operand + END
 
 
 @lowerOperation.register
-def _(op: arith.Constant):
-    value = op.value.value.data
+def _(op: arith.ConstantOp):
+    value = op.value.value.data  # type: ignore
+    assert isinstance(value, int) or isinstance(value, float)
     assert isinstance(op.results[0].type, IntegerType)
     size = op.results[0].type.width.data
+    max_val_plus_one = 1 << size
     returnedType = "int"
-    if value > ((1 << 31) - 1):
+    if value >= (1 << 31):
         assert False and "arith constant overflow maximal int"
-    returnedValue = op.results[0].name_hint
-    return indent + returnedType + " " + returnedValue + " = " + str(value) + ends
+    returnedValue = get_ret_val(op)
+    return (
+        IDNT
+        + returnedType
+        + " "
+        + returnedValue
+        + EQ
+        + str((value + max_val_plus_one) % max_val_plus_one)
+        + END
+    )
 
 
 @lowerOperation.register
 def _(op: Constant):
     value = op.value.value.data
     returnedType = lowerType(op.results[0].type)
-    returnedValue = op.results[0].name_hint
+    returnedValue = get_ret_val(op)
     return (
-        indent
+        IDNT
         + returnedType
         + " "
         + returnedValue
         + "("
-        + op.operands[0].name_hint
+        + get_operand(op, 0)
         + ".getBitWidth(),"
         + str(value)
         + ")"
-        + ends
+        + END
     )
 
 
 @lowerOperation.register
 def _(op: GetAllOnesOp):
-    returnedType = lowerType(op.results[0].type)
-    returnedValue = op.results[0].name_hint
-    opName = operNameToCpp[op.name]
+    ret_type = lowerType(op.results[0].type)
+    ret_val = get_ret_val(op)
+    op_name = get_op_str(op)
+
     return (
-        indent
-        + returnedType
+        IDNT
+        + ret_type
         + " "
-        + returnedValue
-        + " = "
-        + opName
+        + ret_val
+        + EQ
+        + op_name
         + "("
-        + op.operands[0].name_hint
+        + get_operand(op, 0)
         + ".getBitWidth()"
         + ")"
-        + ends
+        + END
     )
 
 
 @lowerOperation.register
-def _(op: Call):
+def _(op: GetSignedMaxValueOp):
+    ret_type = lowerType(op.results[0].type)
+    ret_val = get_ret_val(op)
+    op_name = get_op_str(op)
+
+    return (
+        IDNT
+        + ret_type
+        + " "
+        + ret_val
+        + EQ
+        + op_name
+        + "("
+        + get_operand(op, 0)
+        + ".getBitWidth()"
+        + ")"
+        + END
+    )
+
+
+@lowerOperation.register
+def _(op: GetSignedMinValueOp):
     returnedType = lowerType(op.results[0].type)
-    returnedValue = op.results[0].name_hint
+    returnedValue = get_ret_val(op)
+    op_name = get_op_str(op)
+
+    return (
+        IDNT
+        + returnedType
+        + " "
+        + returnedValue
+        + EQ
+        + op_name
+        + "("
+        + get_operand(op, 0)
+        + ".getBitWidth()"
+        + ")"
+        + END
+    )
+
+
+@lowerOperation.register
+def _(op: CallOp):
+    returnedType = lowerType(op.results[0].type)
+    returnedValue = get_ret_val(op)
     callee = op.callee.string_value() + "("
-    operandsName = [oper.name_hint for oper in op.operands]
+    operandsName = get_op_names(op)
     expr = ""
     if len(operandsName) > 0:
         expr += operandsName[0]
     for i in range(1, len(operandsName)):
         expr += "," + operandsName[i]
     expr += ")"
-    return indent + returnedType + " " + returnedValue + "=" + callee + expr + ends
+    return IDNT + returnedType + " " + returnedValue + EQ + callee + expr + END
+
+
+def set_clear_bits(
+    op: SetHighBitsOp | SetLowBitsOp | ClearHighBitsOp | ClearLowBitsOp,
+) -> str:
+    ret_ty = lowerType(op.results[0].type, op)
+    ret_val = get_ret_val(op)
+    arg = get_operand(op, 0)
+    count = get_operand(op, 1)
+    op_str = get_op_str(op)
+
+    set_val = f"{IDNT}{ret_ty} {ret_val} = {arg};\n"
+    cond = f"{count}.ule({count}.getBitWidth())"
+    if_br = f"{IDNT}{IDNT}{ret_val}{op_str}({count}.getZExtValue());\n"
+    el_br = f"{IDNT}{IDNT}{ret_val}{op_str}({count}.getBitWidth());\n"
+
+    return f"{set_val}{IDNT}if ({cond})\n{if_br}{IDNT}else\n{el_br}"
 
 
 @lowerOperation.register
 def _(op: FuncOp):
-    def lowerArgs(arg):
+    def lowerArgs(arg: BlockArgument) -> str:
+        assert arg.name_hint
         return lowerType(arg.type) + " " + arg.name_hint
 
     returnedType = lowerType(op.function_type.outputs.data[0])
@@ -535,21 +734,23 @@ def _(op: FuncOp):
     for i in range(1, len(op.args)):
         expr += "," + lowerArgs(op.args[i])
     expr += ")"
-    # return returnedType + " " + funcName + expr + "{{\n{0}}}\n\n"
-    return returnedType + " " + funcName + expr + "{\n"
+
+    return returnedType + " " + funcName + expr + "{\n"  # }
 
 
-def castToAPIntFromUnsigned(op: Operation):
-    lastReturn = op.results[0].name_hint + "_autocast"
+def castToAPIntFromUnsigned(op: Operation) -> str:
+    returnedValue = get_ret_val(op)
+    lastReturn = returnedValue + "_autocast"
     apInt = None
     for operand in op.operands:
         if isinstance(operand.type, TransIntegerType):
             apInt = operand.name_hint
             break
     returnedType = "APInt"
-    returnedValue = op.results[0].name_hint
+    assert apInt
+
     return (
-        indent
+        IDNT
         + returnedType
         + " "
         + returnedValue
@@ -558,8 +759,28 @@ def castToAPIntFromUnsigned(op: Operation):
         + ".getBitWidth(),"
         + lastReturn
         + ")"
-        + ends
+        + END
     )
+
+
+@lowerOperation.register
+def _(op: SDivOp):
+    return lowerToClassMethod(op, None, None)
+
+
+@lowerOperation.register
+def _(op: UDivOp):
+    return lowerToClassMethod(op, None, None)
+
+
+@lowerOperation.register
+def _(op: SRemOp):
+    return lowerToClassMethod(op, None, None)
+
+
+@lowerOperation.register
+def _(op: URemOp):
+    return lowerToClassMethod(op, None, None)
 
 
 @lowerOperation.register
@@ -587,34 +808,57 @@ def _(op: CountRZeroOp):
     return lowerToClassMethod(op, None, castToAPIntFromUnsigned)
 
 
-def castToUnisgnedFromAPInt(operand):
-    if isinstance(operand.type, TransIntegerType):
-        return operand.name_hint + ".getZExtValue()"
-    return operand.name_hint
+def castToUnisgnedFromAPInt(operand: SSAValue | str) -> str:
+    if isinstance(operand, str):
+        return "(" + operand + ").getZExtValue()"
+    elif isinstance(operand.type, TransIntegerType):
+        return f"{operand.name_hint}.getZExtValue()"
+
+    return str(operand.name_hint)
 
 
 @lowerOperation.register
 def _(op: SetHighBitsOp):
-    returnedType = lowerType(op.results[0].type, op)
-    returnedValue = op.results[0].name_hint
-    equals = "=" + op.operands[0].name_hint + ends + "\t"
-    expr = op.results[0].name_hint + operNameToCpp[op.name] + "("
-    operands = op.operands[1].name_hint + ".getZExtValue()"
-    expr = expr + operands + ")"
-    result = returnedType + " " + returnedValue + equals + expr + ends
-    return indent + result
+    return set_clear_bits(op)
 
 
 @lowerOperation.register
 def _(op: SetLowBitsOp):
+    return set_clear_bits(op)
+
+
+@lowerOperation.register
+def _(op: ClearHighBitsOp):
+    return set_clear_bits(op)
+
+
+@lowerOperation.register
+def _(op: ClearLowBitsOp):
+    return set_clear_bits(op)
+
+
+@lowerOperation.register
+def _(op: SetSignBitOp):
     returnedType = lowerType(op.results[0].type, op)
-    returnedValue = op.results[0].name_hint
-    equals = "=" + op.operands[0].name_hint + ends + "\t"
-    expr = op.results[0].name_hint + operNameToCpp[op.name] + "("
-    operands = op.operands[1].name_hint + ".getZExtValue()"
+    returnedValue = get_ret_val(op)
+    equals = EQ + get_operand(op, 0) + END + IDNT
+    expr = returnedValue + get_op_str(op) + "("
+    operands = ""
     expr = expr + operands + ")"
-    result = returnedType + " " + returnedValue + equals + expr + ends
-    return indent + result
+
+    return IDNT + returnedType + " " + returnedValue + equals + expr + END
+
+
+@lowerOperation.register
+def _(op: ClearSignBitOp):
+    returnedType = lowerType(op.results[0].type, op)
+    returnedValue = get_ret_val(op)
+    equals = EQ + get_operand(op, 0) + END + IDNT
+    expr = returnedValue + get_op_str(op) + "("
+    operands = ""
+    expr = expr + operands + ")"
+
+    return IDNT + returnedType + " " + returnedValue + equals + expr + END
 
 
 @lowerOperation.register
@@ -623,97 +867,44 @@ def _(op: GetLowBitsOp):
 
 
 @lowerOperation.register
+def _(op: GetHighBitsOp):
+    return lowerToClassMethod(op, castToUnisgnedFromAPInt)
+
+
+@lowerOperation.register
 def _(op: GetBitWidthOp):
     return lowerToClassMethod(op, None, castToAPIntFromUnsigned)
 
 
-# op1 < op2? op1: op2
 @lowerOperation.register
 def _(op: SMaxOp):
-    returnedType = lowerType(op.operands[0].type, op)
-    returnedValue = op.results[0].name_hint
-    operands = [operand.name_hint for operand in op.operands]
-    operator = operNameToCpp[op.name]
-    equals = "="
-    expr = (
-        operands[0]
-        + operator[0]
-        + "("
-        + operands[1]
-        + ")"
-        + operator[1]
-        + operands[0]
-        + operator[2]
-        + operands[1]
-    )
-    result = returnedType + " " + returnedValue + equals + expr + ends
-    return indent + result
+    return lower_min_max(op)
 
 
 @lowerOperation.register
 def _(op: SMinOp):
-    returnedType = lowerType(op.operands[0].type, op)
-    returnedValue = op.results[0].name_hint
-    operands = [operand.name_hint for operand in op.operands]
-    operator = operNameToCpp[op.name]
-    equals = "="
-    expr = (
-        operands[0]
-        + operator[0]
-        + "("
-        + operands[1]
-        + ")"
-        + operator[1]
-        + operands[0]
-        + operator[2]
-        + operands[1]
-    )
-    result = returnedType + " " + returnedValue + equals + expr + ends
-    return indent + result
+    return lower_min_max(op)
 
 
 @lowerOperation.register
 def _(op: UMaxOp):
-    returnedType = lowerType(op.operands[0].type, op)
-    returnedValue = op.results[0].name_hint
-    operands = [operand.name_hint for operand in op.operands]
-    operator = operNameToCpp[op.name]
-    equals = "="
-    expr = (
-        operands[0]
-        + operator[0]
-        + "("
-        + operands[1]
-        + ")"
-        + operator[1]
-        + operands[0]
-        + operator[2]
-        + operands[1]
-    )
-    result = returnedType + " " + returnedValue + equals + expr + ends
-    return indent + result
+    return lower_min_max(op)
 
 
 @lowerOperation.register
 def _(op: UMinOp):
+    return lower_min_max(op)
+
+
+def lower_min_max(op: UMinOp | UMaxOp | SMinOp | SMaxOp) -> str:
     returnedType = lowerType(op.operands[0].type, op)
-    returnedValue = op.results[0].name_hint
-    operands = [operand.name_hint for operand in op.operands]
-    operator = operNameToCpp[op.name]
-    equals = "="
-    expr = (
-        operands[0]
-        + operator[0]
-        + "("
-        + operands[1]
-        + ")"
-        + operator[1]
-        + operands[0]
-        + operator[2]
-        + operands[1]
-    )
-    result = returnedType + " " + returnedValue + equals + expr + ends
-    return indent + result
+    returnedValue = get_ret_val(op)
+    operands = get_op_names(op)
+    operator = get_op_str(op)
+
+    expr = operator + "(" + operands[0] + "," + operands[1] + ")"
+
+    return IDNT + returnedType + " " + returnedValue + EQ + expr + END
 
 
 @lowerOperation.register
@@ -751,111 +942,91 @@ def _(op: ConstRangeForOp):
     indvar, *block_iter_args = loopBody.args
     iter_args = op.iter_args
 
-    global indent
     loopBefore = ""
     for i, blk_arg in enumerate(block_iter_args):
         iter_type = lowerType(iter_args[i].type, iter_args[i].owner)
         iter_name = blk_arg.name_hint
-        loopBefore += (
-            indent + iter_type + " " + iter_name + " = " + iter_args[i].name_hint + ends
-        )
+        iter_arg = iter_args[i].name_hint
+        assert iter_name
+        assert iter_arg
 
-    loopFor = indent + "for(APInt {0} = {1}; {0}.ule({2}); {0}+={3}){{\n".format(
+        loopBefore += IDNT + iter_type + " " + iter_name + EQ + iter_arg + END
+
+    loopFor = IDNT + "for(APInt {0} = {1}; {0}.ule({2}); {0}+={3}){{\n".format(
         indvar.name_hint, lowerBound, upperBound, step
     )
-    indent += "\t"
-    """
-    mainLoop=""
-    for loopOp in loopBody.ops:
-        mainLoop+=(indent  + indent+ lowerOperation(loopOp))
-    endLoopFor=indent+"}\n"
-    """
+
     return loopBefore + loopFor
 
 
 @lowerOperation.register
-def _(op: NextLoopOp):
+def _(op: NextLoopOp) -> str:
     loopBlock = op.parent_block()
-    indvar, *block_iter_args = loopBlock.args
-    global indent
+    assert loopBlock
+    _, *block_iter_args = loopBlock.args
     assignments = ""
     for i, arg in enumerate(op.operands):
-        assignments += (
-            indent + block_iter_args[i].name_hint + " = " + arg.name_hint + ends
-        )
-    indent = indent[:-1]
-    endLoopFor = indent + "}\n"
+        block_arg = block_iter_args[i].name_hint
+        arg_name = arg.name_hint
+        assert block_arg
+        assert arg_name
+
+        assignments += IDNT + block_arg + EQ + arg_name + END
+
+    endLoopFor = IDNT + "}\n"
     loopOp = loopBlock.parent_op()
+    assert loopOp
+
     for i, res in enumerate(loopOp.results):
-        endLoopFor += (
-            indent
-            + lowerType(res.type, loopOp)
-            + " "
-            + res.name_hint
-            + " = "
-            + block_iter_args[i].name_hint
-            + ends
-        )
+        ty = lowerType(res.type, loopOp)
+        res_name = res.name_hint
+        block_arg = block_iter_args[i].name_hint
+        assert res_name
+        assert block_arg
+
+        endLoopFor += IDNT + ty + " " + res_name + EQ + block_arg + END
+
     return assignments + endLoopFor
 
 
 @lowerOperation.register
 def _(op: RepeatOp):
     returnedType = lowerType(op.operands[0].type, op)
-    returnedValue = op.results[0].name_hint
-    arg0_name = op.operands[0].name_hint
-    count = op.operands[1].name_hint
-    initExpr = indent + returnedType + " " + returnedValue + " = " + arg0_name + ends
+    returnedValue = get_ret_val(op)
+    arg0_name = get_operand(op, 0)
+    count = get_operand(op, 1)
+    initExpr = IDNT + returnedType + " " + returnedValue + EQ + arg0_name + END
     forHead = (
-        indent
-        + "for(APInt i("
-        + count
-        + ".getBitWidth(),1);i.ult("
-        + count
-        + ");++i){\n"
+        IDNT + "for(APInt i(" + count + ".getBitWidth(),1);i.ult(" + count + ");++i){\n"
     )
     forBody = (
-        indent
-        + "\t"
+        IDNT
+        + IDNT
         + returnedValue
-        + " = "
+        + EQ
         + returnedValue
         + ".concat("
         + arg0_name
         + ")"
-        + ends
+        + END
     )
-    forEnd = indent + "}\n"
+    forEnd = IDNT + "}\n"
     return initExpr + forHead + forBody + forEnd
 
 
 @lowerOperation.register
 def _(op: AddPoisonOp):
     returnedType = lowerType(op.results[0].type)
-    returnedValue = op.results[0].name_hint
-    opName = operNameToCpp[op.name]
-    return (
-        indent
-        + returnedType
-        + " "
-        + returnedValue
-        + " = "
-        + op.operands[0].name_hint
-        + ends
-    )
+    returnedValue = get_ret_val(op)
+    operand = get_operand(op, 0)
+
+    return IDNT + returnedType + " " + returnedValue + EQ + operand + END
 
 
 @lowerOperation.register
-def _(op: RemovePoisonOp):
+def _(op: RemovePoisonOp) -> str:
     returnedType = lowerType(op.results[0].type)
-    returnedValue = op.results[0].name_hint
-    opName = operNameToCpp[op.name]
-    return (
-        indent
-        + returnedType
-        + " "
-        + returnedValue
-        + " = "
-        + op.operands[0].name_hint
-        + ends
-    )
+    returnedValue = get_ret_val(op)
+    operand = get_operand(op, 0)
+
+    return IDNT + returnedType + " " + returnedValue + EQ + operand + END


### PR DESCRIPTION
Lowering from MLIR to C++ has been broken in the upstream xdsl-smt repo for a quite some, while the synthesizing transfer functions repository has made a bunch of project specific changes to the lowering. This PR aims to fix the lowering in the xdsl-smt repo, without adding any synth-transformers specific code. 
Note that type checking has been turned back on in `xdsl_smt/utils/lower_utils.py` and `xdsl_smt/passes/transfer_lower.py` which will hopefully make this more maintainable in the future.
Also I do not have a huge corpus of MLIR files on my machine, so further testing would be hugely appreciated