### PR TITLE
only print pair datatype def if emitted smt-lib code will use it

### DIFF
--- a/tests/filecheck/dialects/int-theory/arithmetic.mlir
+++ b/tests/filecheck/dialects/int-theory/arithmetic.mlir
@@ -33,8 +33,7 @@
       %mod = "smt.int.mod"(%x, %y) : (!smt.int.int, !smt.int.int) -> !smt.int.int
   }) : () -> ()
 
-// CHECK:       (declare-datatypes ((Pair 2)) ((par (X Y) ((pair (first X) (second Y))))))
-// CHECK-NEXT:  (assert (let (($x 42))
+// CHECK:       (assert (let (($x 42))
 // CHECK-NEXT:    (let (($y 84))
 // CHECK-NEXT:    (< $x $y))))
 // CHECK-NEXT:  (assert (let (($x 42))

--- a/xdsl_smt/traits/smt_printer.py
+++ b/xdsl_smt/traits/smt_printer.py
@@ -241,12 +241,18 @@ def print_to_smtlib(module: ModuleOp, stream: IO[str]) -> None:
     Print a program to its SMTLib representation.
     """
     ctx = SMTConversionCtx()
-    # We use this hack for now
-    # TODO: check for usage of pairs in the program to not always print this.
-    print(
-        "(declare-datatypes ((Pair 2)) ((par (X Y) ((pair (first X) (second Y))))))",
-        file=stream,
-    )
+
+    # only print the datatype def if the emmited smt code will have a pair
+    if any(
+        getattr(value.type, "name", None) == "smt.utils.pair"
+        for op in module.walk()
+        for value in (*op.operands, *op.results)
+    ):
+        print(
+            "(declare-datatypes ((Pair 2)) ((par (X Y) ((pair (first X) (second Y))))))",
+            file=stream,
+        )
+
     for op in module.ops:
         if isinstance(op, SMTLibScriptOp):
             op.print_expr_to_smtlib(stream, ctx)


### PR DESCRIPTION
There was this todo in smt-printer the code for a while:  
`# TODO: check for usage of pairs in the program to not always print this`
where smt-printer would always put this datatype decl in emitted smt-lib code: 
`(declare-datatypes ((Pair 2)) ((par (X Y) ((pair (first X) (second Y))))))`

I wanted to use some other solvers including bitwuzla, which doesn't support `declare-datatypes`, so this line prevents any of those solvers from running even if the resulting code doesn't include any pairs. so by adding a small check to see if the mlir even has a `smt.utils.pair` in it, we can conditionally emit the datatype decl, without breaking any functionality, while allowing more compatibility with solvers other than z3
